### PR TITLE
feat(repl,adhoc): many added ad-hoc .<HELPER>s, improve repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Ad-hoc commands (REPL only):
   - Example: `.labels http_requests_total`
 - `.metrics`
   - List metric names present in the loaded dataset
+- `.timestamps <metric>`
+  - Summarize timestamps found across the metric's time series (unique count, earliest, latest, span)
+  - Example: `.timestamps http_requests_total`
 - `.seed <metric> [steps=N] [step=1m]`
   - Backfill N historical points per series for a metric, spaced by step (enables rate()/increase())
   - Also supports positional form: `.seed <metric> <steps> [<step>]`

--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ Ad-hoc commands (REPL only):
   - Backfill N historical points per series for a metric, spaced by step (enables rate()/increase())
   - Also supports positional form: `.seed <metric> <steps> [<step>]`
   - Examples: `.seed http_requests_total steps=10 step=30s` or `.seed http_requests_total 10 30s`
-- `.scrape <URI>`
-  - Fetch metrics from an HTTP(S) endpoint in Prometheus text exposition format and load them into the store
-  - Example: `.scrape http://localhost:9100/metrics`
+- `.scrape <URI> [metrics_regex] [count] [delay]`
+  - Fetch metrics from an HTTP(S) endpoint and load them into the store, optionally filtering by metric name regex, repeating count times with delay between scrapes
+  - Examples:
+    - `.scrape http://localhost:9100/metrics`
+    - `.scrape http://localhost:9100/metrics '^(up|process_.*)$'`
+    - `.scrape http://localhost:9100/metrics 3 5s`
+    - `.scrape http://localhost:9100/metrics 'http_.*' 5 2s`
 - `.drop <metric>`
   - Remove a metric (all its series) from the in-memory store
   - Example: `.drop http_requests_total`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Ad-hoc commands (REPL only):
 - `.timestamps <metric>`
   - Summarize timestamps found across the metric's time series (unique count, earliest, latest, span)
   - Example: `.timestamps http_requests_total`
+- `.load <file.prom>`
+  - Load metrics from a Prometheus text-format file into the store
+- `.save <file.prom>`
+  - Save current store to a Prometheus text-format file
 - `.seed <metric> [steps=N] [step=1m]`
   - Backfill N historical points per series for a metric, spaced by step (enables rate()/increase())
   - Also supports positional form: `.seed <metric> <steps> [<step>]`
@@ -61,6 +65,10 @@ Ad-hoc commands (REPL only):
   - Evaluate a query at a specific time
   - Time formats: now, now-5m, now+1h, RFC3339 (2025-09-16T20:40:00Z), unix seconds/millis
   - Example: `.at now-10m sum by (path) (rate(http_requests_total[5m]))`
+- `.pinat [time|now|remove]`
+  - Without args, show current pinned evaluation time
+  - With an argument, pin all future queries to a specific evaluation time until removed
+  - Examples: `.pinat` (show), `.pinat now`, `.pinat 2025-09-16T20:40:00Z`, `.pinat remove`
 
 With the built binary:
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,38 @@
 # promql-cli
 
-An in-memory PromQL playground/REPL. It loads Prometheus text exposition format metrics into a simple in-memory store and executes PromQL using the upstream Prometheus engine. Includes interactive querying with readline-based history and dynamic auto-completion for metric names, labels, values, functions, and operators derived from the loaded dataset.
+A lightweight PromQL playground and REPL. Load Prometheus text-format metrics, query them with the upstream Prometheus engine, and iterate quickly with interactive auto-completion.
 
-## Build
+## Install
 
-- Local build:
-  - `make build`
-  - Binary: `./bin/promql-cli`
+- Go:
+  - `go install github.com/jjo/promql-cli@latest`
+- Docker:
+  - Docker Hub: `docker pull xjjo/promql-cli:latest`
+  - GHCR: `docker pull ghcr.io/jjo/promql-cli:latest`
 
-- Run without building:
-  - `go run . <command> <file.prom>`
+## Quick start
 
-## CLI usage
+- Load a metrics file and open the REPL:
+  - `promql-cli query ./example.prom`
+- Scrape metrics before starting and list metric names:
+  - `promql-cli query -c ".scrape http://localhost:9100/metrics; .metrics"`
+- Run a single query and print JSON:
+  - `promql-cli query -q 'up' -o json ./example.prom`
 
-Commands (from the program):
+## Commands
 
-- Load metrics (parse + summarize):
-  - `go run . load <file.prom>`
-- Query (REPL with autocomplete):
-  - `go run . query [flags] <file.prom>`
+- `promql-cli load <file.prom>` — parse and load a text-format metrics file (prints a short summary)
+- `promql-cli query [flags] [<file.prom>]` — start the REPL or run a one-off query
+- `promql-cli version` — print version, commit, and build date
 
-Flags (query mode):
+### Query flags
+- `-q, --query "<expr>"` — run a single expression and exit
+- `-o, --output json` — with `-q`, print JSON result
+- `-c, --command "cmds"` — run semicolon-separated commands before the session or one-off query
+  - Example: `-c ".scrape http://localhost:9100/metrics; .metrics"`
+- `-s, --silent` — suppress startup output and `-c` command output
 
-- `-q, --query "<expr>"`  Execute a single PromQL expression and exit (no REPL)
-- `-o, --output json`      With -q, output results as JSON (vector/scalar/matrix)
-- `-c, --command "cmds"`  Run semicolon-separated commands before the session or one-off query
-  - Example: `promql-cli query -c ".scrape http://localhost:9100/metrics" -s -q 'count by (__name__)({__name__!=""}) > 1'`
-
-Common flags:
-
-- `-s, --silent`           Suppress startup output (banners, summaries)
-
-Ad-hoc commands (REPL only):
+## Ad-hoc commands (in the REPL)
 
 - `.help`
   - Show usage for ad-hoc commands
@@ -70,34 +71,147 @@ Ad-hoc commands (REPL only):
   - With an argument, pin all future queries to a specific evaluation time until removed
   - Examples: `.pinat` (show), `.pinat now`, `.pinat 2025-09-16T20:40:00Z`, `.pinat remove`
 
-With the built binary:
-
-- `./bin/promql-cli load <file.prom>`
-- `./bin/promql-cli query [flags] <file.prom>`
-- `./bin/promql-cli test-completion <file.prom>`
-
-Examples (non-interactive and JSON):
-
-Initialization examples (`-c`):
-
-- Initialize by scraping and list metrics, then start REPL:
-  - `./bin/promql-cli query -c ".scrape http://localhost:9100/metrics; .metrics"`
-- Initialize, then run a one-off query and exit:
-  - `./bin/promql-cli query -c ".scrape http://localhost:9100/metrics" -q 'sum(up)'`
-
-- One-off query and exit:
-  - `./bin/promql-cli query -q 'sum(rate(http_requests_total[5m]))' metrics.prom`
-- JSON output (Prometheus-like shape):
-  - `./bin/promql-cli query -q 'up' -o json metrics.prom`
-- Suppress startup output:
-  - `./bin/promql-cli query -s metrics.prom`
-
-Notes:
-
-- `<file.prom>` must be in Prometheus text exposition format.
+## Notes
+- Input files must be in Prometheus text exposition format.
 - The REPL supports tab-completion and keeps history in `/tmp/.promql-cli_history`.
 
-## Examples
+## Use cases
+
+### Developing an exporter
+Use promql-cli to iterate quickly on metrics emitted by your exporter during development.
+- Repeatedly scrape your local exporter while you code.
+- Pin evaluation time to "now" for stable rate/increase windows during quick loops.
+- Explore labels with `.labels` and use Tab completion to discover series.
+
+Example:
+
+```
+./bin/promql-cli query -c ".scrape http://localhost:9123/metrics ^awesome_metric 3 10s; .pinat now"
+> .labels awesome_metric<TAB>
+> rate(awesome_metric_foo_total[30s])
+```
+
+<details>
+<summary>Flow</summary>
+
+```
+Dev edits code
+     │
+     ▼
+Exporter (localhost:9123/metrics) ──▶ promql-cli .scrape (repeat count/delay)
+                                      │
+                                      ▼
+                               In-memory store
+                                      │
+                                      ▼
+                         REPL (completion, .labels, .pinat)
+                                      │
+                                      ▼
+                             Queries (rate/increase)
+                                      │
+                                      ▼
+                                 Insights/iterate ↺
+```
+
+</details>
+
+### Grabbing exported metrics from a Kubernetes pod
+Port-forward the pod or service locally, scrape a few times, explore, and save for offline analysis later.
+
+```
+# Port-forward a service or pod (adjust namespace/name)
+kubectl -n <namespace> port-forward svc/<service> 9123:9123 &
+
+./bin/promql-cli query -c ".scrape http://localhost:9123/metrics ^awesome_metric 3 10s; .pinat now"
+> .labels awesome_metric<TAB>
+> rate(awesome_metric_foo_total[30s])
+> .save exported.prom
+```
+
+Later reload and continue exploring:
+
+```
+./bin/promql-cli query -c ".load exported.prom"
+> .timestamps awesome_metric_foo_total
+> .pinat <last_timestamp_from_above>
+> rate(awesome_metric_foo_total[30s])
+```
+
+<details>
+<summary>Flow</summary>
+
+```
+K8s Pod/Service ──(port-forward 9123)──▶ localhost:9123/metrics
+                                         │
+                                         ▼
+                                   promql-cli .scrape (×N)
+                                         │
+                                         ▼
+                                   In-memory store
+                                         │            ┌───────────────┐
+                                         ├──────────▶ │ .save snapshot │───▶ exported.prom
+                                         │            └───────────────┘
+                                         ▼
+                                      Explore
+                                         │
+                                         ▼
+                                   Later: .load file
+                                         │
+                                         ▼
+                                      Explore again
+```
+
+</details>
+
+### Other ideas
+- Validate alerts and recording rules locally: run PromQL expressions against a saved snapshot to check thresholds.
+
+<details>
+<summary>Flow</summary>
+
+```
+exported.prom ──▶ promql-cli query -c ".load exported.prom" ──▶ run expressions ──▶ validate thresholds
+```
+
+</details>
+
+- Teach/learn PromQL: use completion, `.seed` to create history for `rate()`/`increase()`, and `.labels` to discover dimensions.
+
+<details>
+<summary>Flow</summary>
+
+```
+minimal dataset ──▶ promql-cli (.seed to synthesize history) ──▶ try functions (rate/increase) ──▶ iterate
+```
+
+</details>
+
+- CI smoke tests for exporters: in CI, run the Docker image, scrape a test exporter, and run a set of queries (via `-q`) to assert presence/shape of metrics.
+
+<details>
+<summary>Flow</summary>
+
+```
+CI runner ──▶ docker run promql-cli query -c ".scrape http://exporter:metrics" -q "required_query"
+         └─▶ exit code + logs enforce expectations
+```
+
+</details>
+
+- Compare snapshots over time: save multiple `.prom` files and load the one you need to analyze regressions or label churn.
+
+<details>
+<summary>Flow</summary>
+
+```
+exported_1.prom   exported_2.prom
+       │                 │
+       └──▶ promql-cli (load one at a time) ──▶ run diff-like queries (by labels/values)
+```
+
+</details>
+
+## Example PromQL queries
 
 - Try the bundled example dataset:
   - `./bin/promql-cli load ./example.prom`
@@ -122,34 +236,7 @@ Notes:
   - `active_sessions`
 
 ## Docker
-
-Image name (default): `xjjo/promql-cli`
-
-- Build:
-  - `make docker-build TAG=latest`
-- Run (mount metrics):
-  - `docker run --rm -it -v "$PWD":/data xjjo/promql-cli:latest query /data/example.prom`
-- Push (to Docker Hub):
-  - `make docker-push TAG=latest`
-
-### GitHub Actions (CI) Docker build & push
-
-This repository includes a GitHub Actions workflow that builds and pushes the Docker image to Docker Hub:
-
-- Triggers: on push to main, and on tags (v*).
-- Tags pushed:
-  - On main: latest and sha-<shortsha>
-  - On tags: the tag name (e.g., v1.2.3) and latest
-
-## Make targets
-
-- `make build`: Build ./bin/promql-cli
-- `make run ARGS="query ./metrics.prom"`: Build then run with ARGS passed to the binary
-- `make test`: Run go test ./...
-- `make fmt`: go fmt ./...
-- `make vet`: go vet ./...
-- `make tidy`: go mod tidy
-- `make clean`: Remove ./bin
-- `make docker-build [TAG=latest]`: Build Docker image xjjo/promql-cli:TAG
-- `make docker-run ARGS="query /data/metrics.prom" [TAG=latest]`: Run the image with ARGS
-- `make docker-push [TAG=latest]`: Push xjjo/promql-cli:TAG
+- Run with a local file mounted:
+  - `docker run --rm -it -v "$PWD":/data xjjo/promql-cli:latest query /data/metrics.prom`
+- Initialize via scrape and enter REPL:
+  - `docker run --rm -it xjjo/promql-cli:latest query -c ".scrape http://localhost:9100/metrics; .metrics"`

--- a/main.go
+++ b/main.go
@@ -66,11 +66,13 @@ func main() {
 
 	// Create upstream Prometheus PromQL engine
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:        nil,
-		Reg:           nil,
-		MaxSamples:    50000000,
-		Timeout:       30 * time.Second,
-		LookbackDelta: 5 * time.Minute,
+		Logger:               nil,
+		Reg:                  nil,
+		MaxSamples:           50000000,
+		Timeout:              30 * time.Second,
+		LookbackDelta:        5 * time.Minute,
+		EnableAtModifier:     true,
+		EnableNegativeOffset: true,
 		NoStepSubqueryIntervalFn: func(rangeMillis int64) int64 {
 			return 60 * 1000 // 60 seconds
 		},

--- a/repl.go
+++ b/repl.go
@@ -363,18 +363,18 @@ func (pac *PrometheusAutoCompleter) getCompletions(line string, pos int, current
 	lastCloseBrace := strings.LastIndex(beforeCursor, "}")
 	inLabels := lastOpenBrace > lastCloseBrace && lastOpenBrace != -1
 
-	if !inLabels && strings.HasPrefix(trimmed, ".") {
-		// If typing the command token, suggest available ad-hoc commands
-		if strings.HasPrefix(currentWord, ".") || strings.TrimSpace(trimmed) == "." {
-			cmds := []string{".help", ".labels", ".metrics", ".seed", ".scrape", ".drop", ".at"}
-			var out []string
-			for _, c := range cmds {
-				if strings.HasPrefix(strings.ToLower(c), strings.ToLower(currentWord)) {
-					out = append(out, c)
+		if !inLabels && strings.HasPrefix(trimmed, ".") {
+			// If typing the command token, suggest available ad-hoc commands
+			if strings.HasPrefix(currentWord, ".") || strings.TrimSpace(trimmed) == "." {
+				cmds := []string{".help", ".labels", ".metrics", ".timestamps", ".seed", ".scrape", ".drop", ".at"}
+				var out []string
+				for _, c := range cmds {
+					if strings.HasPrefix(strings.ToLower(c), strings.ToLower(currentWord)) {
+						out = append(out, c)
+					}
 				}
+				return out
 			}
-			return out
-		}
 		// If after ".labels " or ".seed ", complete metric names
 		if strings.HasPrefix(trimmed, ".labels ") || strings.HasPrefix(trimmed, ".seed ") {
 			return pac.getMetricNameCompletions(currentWord)

--- a/repl.go
+++ b/repl.go
@@ -168,8 +168,11 @@ func runInteractiveQueries(engine *promql.Engine, storage *SimpleStorage, silent
 			continue
 		}
 
-		// Support ".at <time> <query>" to set evaluation time
+		// Evaluate at pinned time if set; allow one-off override via .at <time> <query>
 		evalTime := time.Now()
+		if pinnedEvalTime != nil {
+			evalTime = *pinnedEvalTime
+		}
 		if strings.HasPrefix(query, ".at ") {
 			parts := strings.Fields(query)
 			if len(parts) >= 3 {
@@ -366,7 +369,7 @@ func (pac *PrometheusAutoCompleter) getCompletions(line string, pos int, current
 		if !inLabels && strings.HasPrefix(trimmed, ".") {
 			// If typing the command token, suggest available ad-hoc commands
 			if strings.HasPrefix(currentWord, ".") || strings.TrimSpace(trimmed) == "." {
-				cmds := []string{".help", ".labels", ".metrics", ".timestamps", ".seed", ".scrape", ".drop", ".at"}
+			cmds := []string{".help", ".labels", ".metrics", ".timestamps", ".load", ".save", ".seed", ".scrape", ".drop", ".at", ".pinat"}
 				var out []string
 				for _, c := range cmds {
 					if strings.HasPrefix(strings.ToLower(c), strings.ToLower(currentWord)) {

--- a/simple_tsdb_test.go
+++ b/simple_tsdb_test.go
@@ -13,7 +13,7 @@ import (
 const sampleMetrics = `
 # HELP http_requests_total Total number of HTTP requests
 # TYPE http_requests_total counter
-http_requests_total{method="get",code="200"} 1027 1710000000000
+http_requests_total{method="get",code="200"} 1027
 http_requests_total{method="get",code="404"} 3
 # HELP temperature Temperature in Celsius
 # TYPE temperature gauge


### PR DESCRIPTION
## Summary

This PR brings several usability and quality improvements to `promql-cli` REPL.

## Key changes

### CLI & REPL

- repl: support `.scrape <URI> [metrics_regex] [count=1] [delay=10s]`
- repl: add `.timestamps <metric>` to show timeseries' timestamps
- repl: add `.load <file.prom>` and `.save <file.prom>`, autocompleting to filepaths
- repl: add `!<cmd>` and `<query...> | <cmd>` support**
- promql: support `@` (at)
- CI: add unit testing for above added features
- improve README.md, focusing on new features' use cases

### Ad-hoc commands

Summary of new _ad-hoc_ features added to the REPL:

- `.scrape <URI> [metrics_regex] [count=1] [delay=10s]`
  - HTTP(S) GET with 20s timeout; expects Prometheus text exposition; loads into store.
  - Optionally filter scraped metrics by regex, repeat `count` times with `delay`.
  - Prints a concise delta summary.
- `.drop <metric>`
  - Removes metric's timeseries from the in-memory store
- `.timestamps <metric>`
  - Show timeseries' timestamps.
- `.load <file.prom>` and `.save <file.prom>`
  - Autocompleting to filepaths.
- `<query...> | <cmd>`
  - Pipe query output to shell command.
- `!<cmd>`
  - Run shell command.

### Versioning

- `Makefile` now derives:
  - `VERSION = git describe --tags --dirty --always`
  - `COMMIT`  = short SHA
  - `DATE`    = UTC timestamp
- Docker publish workflow computes version from tag or short SHA and passes build-args.

### CI/CD

- Improved .github/workflows/docker-publish.yml
- Added .github/workflows/test.yml
- docker-publish workflow:
  - Uses docker/metadata-action for tags/labels
  - Adds provenance control and OCI labels
  - Multi-arch build (linux/amd64, linux/arm64)

### Documentation
- README updates:
  - Audience oriented
  - Docs for new REPL features
  - Usage examples
