### PR TITLE
many UX fixes

### DIFF
--- a/adhoc.go
+++ b/adhoc.go
@@ -206,7 +206,7 @@ func handleAdHocFunction(query string, storage *SimpleStorage) bool {
 				}
 			}
 			fmt.Println("Choose with: .ai edit <N>  or  .ai run <N>  (1-based)")
-			fmt.Println("Tips: Alt-1..Alt-9 to paste a suggestion; Ctrl-Y to paste the first suggestion.")
+			fmt.Println("Tips: Alt-1..Alt-9 to paste a suggestion; Ctrl-Y to paste the first suggestion; Tab to show the dropdown.")
 		}(args)
 		// Return immediately to keep the prompt interactive
 		return true

--- a/repl.go
+++ b/repl.go
@@ -1169,7 +1169,7 @@ func executeOne(engine *promql.Engine, storage *SimpleStorage, line string) {
 	// Ad-hoc commands (support piping for their printed output)
 	if strings.HasPrefix(query, ".") {
 		if hasPipe {
-			captured, _ := captureStdout(func() {
+captured, _ := captureOutput(func() {
 				_ = handleAdHocFunction(query, storage)
 			})
 			if aiInProgress {
@@ -1247,7 +1247,7 @@ func executeOne(engine *promql.Engine, storage *SimpleStorage, line string) {
 
 	if hasPipe {
 		// Capture the normal printed output and feed it to the pipe command
-		captured, _ := captureStdout(func() { printUpstreamQueryResult(result) })
+captured, _ := captureOutput(func() { printUpstreamQueryResult(result) })
 		cmd := exec.Command("/bin/sh", "-c", pipeCmd)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -1272,8 +1272,8 @@ func executeOne(engine *promql.Engine, storage *SimpleStorage, line string) {
 	printUpstreamQueryResult(result)
 }
 
-// captureStdout captures stdout produced by fn and returns it as a string.
-func captureStdout(fn func()) (string, error) {
+// captureOutput captures stdout produced by fn and returns it as a string.
+func captureOutput(fn func()) (string, error) {
 	orig := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/repl_dispatch_prompt.go
+++ b/repl_dispatch_prompt.go
@@ -29,14 +29,6 @@ func runInteractiveQueriesDispatch(engine *promql.Engine, storage *SimpleStorage
 func runPromptREPL(engine *promql.Engine, storage *SimpleStorage, silent bool) {
 	if !silent {
 		fmt.Println("Enter PromQL queries (or 'quit' to exit):")
-		fmt.Println("Supported queries:")
-		fmt.Println("  - Basic selectors: metric_name, metric_name{label=\"value\"}")
-		fmt.Println("  - Aggregations: sum(metric_name), avg(metric_name), count(metric_name), min(metric_name), max(metric_name)")
-		fmt.Println("  - Group by: sum(metric_name) by (label)")
-		fmt.Println("  - Binary operations: metric_name + 10, metric_name1 * metric_name2")
-		fmt.Println("  - Functions: rate(metric_name), increase(metric_name), abs(metric_name)")
-		fmt.Println("  - Comparisons: metric_name > 100, metric_name == 0")
-		fmt.Println("  - Ad-hoc commands: .help, .labels <metric>, .metrics, .seed <metric> [steps=N] [step=1m], .at <time> <query>")
 		fmt.Println()
 	}
 


### PR DESCRIPTION
- `repl=prompt` (default): allow `.ai ask <question>` to be interruptable via Ctrl-C
- other small cleanups
- let cursor-up/down usage in go-prompt dropdown(s)
- let `|<ext-cmd>` also work for ad-hoc `.cmds`
