### PR TITLE
feat(adhoc): add remote prometheus scraping, converting results "back" to metrics storage format; big adhoc.go refactor

### DIFF
--- a/adhoc.go
+++ b/adhoc.go
@@ -1,18 +1,9 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"net/http"
-	"os"
-	"regexp"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
-
-	promparser "github.com/prometheus/prometheus/promql/parser"
 )
 
 // pinnedEvalTime, when set, forces future query evaluation to use this timestamp.
@@ -42,688 +33,102 @@ var aiCancelRequest func()
 var aiInProgress bool
 
 func handleAdHocFunction(query string, storage *SimpleStorage) bool {
+	trimmed := strings.TrimSpace(query)
 	// .help: show ad-hoc commands usage
-	if strings.HasPrefix(query, ".help") {
+	if strings.HasPrefix(trimmed, ".help") {
 		handleHelpCommand()
 		return true
 	}
 
 	// .ai: AI-assisted query suggestions
-	if strings.HasPrefix(strings.TrimSpace(query), ".ai") {
-		args := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".ai"))
-		if args == "" || args == "help" { // help
-			fmt.Println("Usage: .ai <intent> | .ai ask <intent> | .ai show | .ai <N> | .ai run <N> | .ai edit <N>")
-			fmt.Println("Examples:")
-			fmt.Println("  .ai top 5 pods by http error rate over last hour")
-			fmt.Println("  .ai 1        # run suggestion [1] if available")
-			fmt.Println("  .ai show     # reprint last suggestions")
+	if strings.HasPrefix(trimmed, ".ai") {
+		if handled := handleAdhocAI(trimmed, storage); handled {
 			return true
 		}
-		// Selection: .ai show
-		if args == "show" {
-			if len(lastAISuggestions) == 0 {
-				fmt.Println("No AI suggestions yet. Try: .ai <intent>")
-				return true
-			}
-			// Activate the inline AI selection workflow (same as post-ask)
-			aiSelectionActive = true
-			fmt.Println("AI suggestions (valid PromQL):")
-			for i, s := range lastAISuggestions {
-				fmt.Printf("  [%d] %s\n", i+1, s)
-				if i < len(lastAIExplanations) {
-					if ex := strings.TrimSpace(lastAIExplanations[i]); ex != "" {
-						fmt.Printf("      - %s\n", ex)
-					}
-				}
-			}
-			fmt.Println("Choose with: .ai edit <N>  or  .ai run <N>  (1-based)")
-			fmt.Println("Tips: use Tab to open the dropdown and pick an item.")
-			return true
-		}
-		// Selection: .ai run N or .ai N
-		if strings.HasPrefix(args, "run ") || regexp.MustCompile(`^\d+$`).MatchString(args) {
-			var idxStr string
-			if strings.HasPrefix(args, "run ") {
-				idxStr = strings.TrimSpace(strings.TrimPrefix(args, "run "))
-			} else {
-				idxStr = args
-			}
-			n, err := strconv.Atoi(idxStr)
-			if err != nil || n <= 0 {
-				fmt.Println("Usage: .ai run <N>  (N is 1-based)")
-				return true
-			}
-			if len(lastAISuggestions) == 0 {
-				fmt.Println("No AI suggestions yet. Try: .ai <intent>")
-				return true
-			}
-			if n > len(lastAISuggestions) {
-				fmt.Printf("Only %d suggestions available\n", len(lastAISuggestions))
-				return true
-			}
-			pendingAISuggestion = lastAISuggestions[n-1]
-			fmt.Printf("Running suggestion [%d]: %s\n", n, pendingAISuggestion)
-			return true
-		}
-		// Selection: .ai edit N
-		if strings.HasPrefix(args, "edit ") {
-			idxStr := strings.TrimSpace(strings.TrimPrefix(args, "edit "))
-			n, err := strconv.Atoi(idxStr)
-			if err != nil || n <= 0 {
-				fmt.Println("Usage: .ai edit <N>  (N is 1-based)")
-				return true
-			}
-			if len(lastAISuggestions) == 0 {
-				fmt.Println("No AI suggestions yet. Try: .ai <intent>")
-				return true
-			}
-			if n > len(lastAISuggestions) {
-				fmt.Printf("Only %d suggestions available\n", len(lastAISuggestions))
-				return true
-			}
-			aiClipboard = lastAISuggestions[n-1]
-			fmt.Printf("Prepared suggestion [%d] for editing. Press Ctrl-Y to paste.\n", n)
-			return true
-		}
-		// Guard: ".ai run" or ".ai edit" without index should not call AI, show usage instead
-		if args == "run" || strings.HasPrefix(args, "run\t") || strings.HasSuffix(args, "run ") {
-			fmt.Println("Usage: .ai run <N>  (N is 1-based)")
-			return true
-		}
-		if args == "edit" || strings.HasPrefix(args, "edit\t") || strings.HasSuffix(args, "edit ") {
-			fmt.Println("Usage: .ai edit <N>  (N is 1-based)")
-			return true
-		}
-		// Support alias: .ai ask <intent>
-		if strings.HasPrefix(args, "ask ") {
-			args = strings.TrimSpace(strings.TrimPrefix(args, "ask "))
-		}
-		// Start AI request asynchronously so Ctrl-C can cancel it while the prompt remains responsive
-		if aiInProgress || aiCancelRequest != nil {
-			fmt.Println("AI request already in progress. Press Ctrl-C to cancel it.")
-			return true
-		}
-		ctx, cancel := context.WithCancel(context.Background())
-		aiCancelRequest = cancel
-		aiInProgress = true
-		fmt.Println("Asking AI... (press Ctrl-C to cancel)")
-		go func(intent string) {
-			defer func() {
-				aiInProgress = false
-				aiCancelRequest = nil
-				cancel()
-			}()
-			suggestions, err := aiSuggestQueriesCtx(ctx, storage, intent)
-			if err != nil {
-				if errors.Is(err, context.Canceled) || strings.Contains(strings.ToLower(err.Error()), "context canceled") || strings.Contains(strings.ToLower(err.Error()), "request canceled") {
-					fmt.Println("AI request canceled")
-					return
-				}
-				fmt.Printf("AI error: %v\n", err)
-				return
-			}
-			var validQ []string
-			var validE []string
-			for _, sug := range suggestions {
-				q := strings.TrimSpace(sug.Query)
-				if q == "" {
-					continue
-				}
-				q = cleanCandidate(q)
-				if q == "" {
-					continue
-				}
-				if _, err := promparser.ParseExpr(q); err == nil {
-					validQ = append(validQ, q)
-					validE = append(validE, strings.TrimSpace(sug.Explain))
-				}
-			}
-			if len(validQ) == 0 {
-				fmt.Println("AI returned no valid PromQL suggestions.")
-				return
-			}
-			lastAISuggestions = validQ
-			lastAIExplanations = validE
-			aiSelectionActive = true
-			fmt.Println("AI suggestions (valid PromQL):")
-			for i := range validQ {
-				fmt.Printf("  [%d] %s\n", i+1, validQ[i])
-				if ex := strings.TrimSpace(validE[i]); ex != "" {
-					fmt.Printf("      - %s\n", ex)
-				}
-			}
-			fmt.Println("Choose with: .ai edit <N>  or  .ai run <N>  (1-based)")
-			fmt.Println("Tips: Alt-1..Alt-9 to paste a suggestion; Ctrl-Y to paste the first suggestion.")
-		}(args)
-		// Return immediately to keep the prompt interactive
-		return true
 	}
 
 	// .history: show full history or last N
-	if strings.HasPrefix(strings.TrimSpace(query), ".history") {
-		fields := strings.Fields(strings.TrimSpace(query))
-		var n int = -1
-		if len(fields) == 2 {
-			if v, err := strconv.Atoi(fields[1]); err == nil && v > 0 {
-				n = v
-			} else {
-				fmt.Println("Usage: .history [N]")
-				return true
-			}
-		} else if len(fields) > 2 {
-			fmt.Println("Usage: .history [N]")
+	if strings.HasPrefix(trimmed, ".history") {
+		if handled := handleAdhocHistory(trimmed, storage); handled {
 			return true
 		}
-		// Prefer in-memory history when available (prompt backend)
-		entries := getInMemoryHistory()
-		if len(entries) == 0 {
-			// Fallback to file
-			path := getHistoryFilePath()
-			entries = loadHistoryFromFile(path)
-		}
-		if len(entries) == 0 {
-			fmt.Println("No history available")
-			return true
-		}
-		start := 0
-		if n > 0 && n < len(entries) {
-			start = len(entries) - n
-		}
-		for i := start; i < len(entries); i++ {
-			fmt.Println(entries[i])
-		}
-		return true
 	}
 
 	// .metrics: list metric names
-	if strings.TrimSpace(query) == ".metrics" {
-		if len(storage.metrics) == 0 {
-			fmt.Println("No metrics loaded")
+	if trimmed == ".metrics" {
+		if handled := handleAdhocMetrics(trimmed, storage); handled {
 			return true
 		}
-		var names []string
-		for name := range storage.metrics {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		fmt.Printf("Metrics (%d):\n", len(names))
-		for _, n := range names {
-			fmt.Printf("  - %s\n", n)
-		}
-		return true
 	}
 
-	// Handle .labels <metric> (preferred) and legacy .labels(metric)
-	if strings.HasPrefix(query, ".labels ") || (strings.HasPrefix(query, ".labels(") && strings.HasSuffix(query, ")")) {
-		var metricName string
-		if strings.HasPrefix(query, ".labels ") {
-			metricName = strings.TrimSpace(strings.TrimPrefix(query, ".labels "))
-		} else {
-			// legacy form
-			metricName = strings.TrimSuffix(strings.TrimPrefix(query, ".labels("), ")")
-		}
-		metricName = strings.Trim(metricName, " \"'")
-
-		if metricName == "" {
-			fmt.Println("Usage: .labels <metric_name>")
-			fmt.Println("Example: .labels cloudcost_azure_aks_storage_by_location_usd_per_gibyte_hour")
+	// Handle .labels <metric>
+	if strings.HasPrefix(trimmed, ".labels") {
+		if handled := handleAdhocLabels(trimmed, storage); handled {
 			return true
 		}
-
-		// Check if metric exists
-		samples, exists := storage.metrics[metricName]
-		if !exists {
-			fmt.Printf("Metric '%s' not found\n", metricName)
-			fmt.Println("Available metrics:")
-			count := 0
-			for name := range storage.metrics {
-				if count >= 5 {
-					fmt.Printf("... and %d more\n", len(storage.metrics)-5)
-					break
-				}
-				fmt.Printf("  - %s\n", name)
-				count++
-			}
-			return true
-		}
-
-		// Collect all unique labels for this metric
-		labelNames := make(map[string]bool)
-		labelValues := make(map[string]map[string]bool)
-
-		for _, sample := range samples {
-			for labelName, labelValue := range sample.Labels {
-				if labelName != "__name__" { // Skip the metric name label
-					labelNames[labelName] = true
-
-					if labelValues[labelName] == nil {
-						labelValues[labelName] = make(map[string]bool)
-					}
-					labelValues[labelName][labelValue] = true
-				}
-			}
-		}
-
-		// Display results
-		fmt.Printf("Labels for metric '%s' (%d samples):\n", metricName, len(samples))
-		if len(labelNames) == 0 {
-			fmt.Println("  No labels found")
-			return true
-		}
-
-		// Sort label names for consistent output
-		var sortedLabels []string
-		for labelName := range labelNames {
-			sortedLabels = append(sortedLabels, labelName)
-		}
-		sort.Strings(sortedLabels)
-
-		for _, labelName := range sortedLabels {
-			values := labelValues[labelName]
-			valueCount := len(values)
-
-			fmt.Printf("  %s (%d values)", labelName, valueCount)
-
-			// Show first few values as examples
-			if valueCount > 0 {
-				var sortedValues []string
-				for value := range values {
-					sortedValues = append(sortedValues, value)
-				}
-				sort.Strings(sortedValues)
-
-				fmt.Printf(": ")
-				if valueCount <= 3 {
-					// Show all values if 3 or fewer
-					for i, value := range sortedValues {
-						if i > 0 {
-							fmt.Printf(", ")
-						}
-						fmt.Printf("%q", value)
-					}
-				} else {
-					// Show first 3 values and indicate there are more
-					for i := 0; i < 3; i++ {
-						if i > 0 {
-							fmt.Printf(", ")
-						}
-						fmt.Printf("%q", sortedValues[i])
-					}
-					fmt.Printf(", ... and %d more", valueCount-3)
-				}
-			}
-			fmt.Println()
-		}
-
-		return true
 	}
 
 	// Handle .timestamps <metric>
-	if strings.HasPrefix(strings.TrimSpace(query), ".timestamps ") || strings.TrimSpace(query) == ".timestamps" {
-		metric := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".timestamps"))
-		metric = strings.Trim(metric, " \"'")
-		if metric == "" {
-			fmt.Println("Usage: .timestamps <metric>")
-			fmt.Println("Example: .timestamps http_requests_total")
+	if strings.HasPrefix(trimmed, ".timestamps ") || trimmed == ".timestamps" {
+		if handled := handleAdhocTimestamps(trimmed, storage); handled {
 			return true
 		}
-		samples, exists := storage.metrics[metric]
-		if !exists || len(samples) == 0 {
-			fmt.Printf("Metric '%s' not found or has no samples\n", metric)
-			return true
-		}
-		// Series count (group by labelset excluding __name__)
-		seriesSet := make(map[string]struct{})
-		for _, s := range samples {
-			// build key excluding __name__
-			keys := make([]string, 0, len(s.Labels))
-			for k := range s.Labels {
-				if k == "__name__" {
-					continue
-				}
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			b := strings.Builder{}
-			for i, k := range keys {
-				if i > 0 {
-					b.WriteByte('\xff') // unlikely separator
-				}
-				b.WriteString(k)
-				b.WriteByte('=')
-				b.WriteString(s.Labels[k])
-			}
-			seriesSet[b.String()] = struct{}{}
-		}
-		seriesCount := len(seriesSet)
-
-		// Unique timestamps and min/max
-		uniq := make(map[int64]int)
-		var minTs, maxTs int64
-		first := true
-		for _, s := range samples {
-			uniq[s.Timestamp]++
-			if first {
-				minTs, maxTs = s.Timestamp, s.Timestamp
-				first = false
-			} else {
-				if s.Timestamp < minTs {
-					minTs = s.Timestamp
-				}
-				if s.Timestamp > maxTs {
-					maxTs = s.Timestamp
-				}
-			}
-		}
-		uniqueCount := len(uniq)
-		span := time.Duration(maxTs-minTs) * time.Millisecond
-		// Prepare example timestamps
-		ts := make([]int64, 0, uniqueCount)
-		for t := range uniq {
-			ts = append(ts, t)
-		}
-		sort.Slice(ts, func(i, j int) bool { return ts[i] < ts[j] })
-		exN := 5
-		if len(ts) < exN {
-			exN = len(ts)
-		}
-		fmt.Printf("Timestamp summary for metric '%s'\n", metric)
-		fmt.Printf("  Series: %d\n", seriesCount)
-		fmt.Printf("  Samples: %d\n", len(samples))
-		fmt.Printf("  Unique timestamps: %d\n", uniqueCount)
-		fmt.Printf("  Earliest: %s (unix_ms=%d)\n", time.UnixMilli(minTs).UTC().Format(time.RFC3339), minTs)
-		fmt.Printf("  Latest:   %s (unix_ms=%d)\n", time.UnixMilli(maxTs).UTC().Format(time.RFC3339), maxTs)
-		fmt.Printf("  Span:     %s\n", span)
-		if exN > 0 {
-			fmt.Printf("  Examples: ")
-			for i := 0; i < exN; i++ {
-				if i > 0 {
-					fmt.Printf(", ")
-				}
-				fmt.Printf("%s", time.UnixMilli(ts[i]).UTC().Format(time.RFC3339))
-			}
-			fmt.Println()
-		}
-		return true
 	}
 
 	// Handle .drop <metric>
-	if strings.HasPrefix(strings.TrimSpace(query), ".drop ") || strings.TrimSpace(query) == ".drop" {
-		metric := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".drop"))
-		metric = strings.TrimSpace(metric)
-		if metric == "" {
-			fmt.Println("Usage: .drop <metric>")
-			fmt.Println("Example: .drop http_requests_total")
+	if strings.HasPrefix(trimmed, ".drop ") || trimmed == ".drop" {
+		if handled := handleAdhocDrop(trimmed, storage); handled {
 			return true
 		}
-		// Check existence
-		samples, exists := storage.metrics[metric]
-		if !exists {
-			fmt.Printf("Metric '%s' not found\n", metric)
-			return true
-		}
-		removed := len(samples)
-		delete(storage.metrics, metric)
-		// Report new totals
-		totalMetrics := len(storage.metrics)
-		totalSamples := 0
-		for _, ss := range storage.metrics {
-			totalSamples += len(ss)
-		}
-		fmt.Printf("Dropped '%s': -%d samples (now: %d metrics, %d samples)\n", metric, removed, totalMetrics, totalSamples)
-
-		// Refresh metrics cache for autocompletion if using prompt backend
-		if refreshMetricsCache != nil {
-			refreshMetricsCache(storage)
-		}
-
-		return true
 	}
 
 	// Handle .save <file.prom>
-	if strings.HasPrefix(strings.TrimSpace(query), ".save ") || strings.TrimSpace(query) == ".save" {
-		path := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".save"))
-		path = strings.Trim(path, " \"'")
-		if path == "" {
-			fmt.Println("Usage: .save <file.prom>")
+	if strings.HasPrefix(trimmed, ".save ") || trimmed == ".save" {
+		if handled := handleAdhocSave(trimmed, storage); handled {
 			return true
 		}
-		f, err := os.Create(path)
-		if err != nil {
-			fmt.Printf("Failed to open %s for writing: %v\n", path, err)
-			return true
-		}
-		defer f.Close()
-		if err := storage.SaveToWriter(f); err != nil {
-			fmt.Printf("Failed to save metrics to %s: %v\n", path, err)
-			return true
-		}
-		fmt.Printf("Saved store to %s\n", path)
-		return true
 	}
 
 	// Handle .load <file.prom>
-	if strings.HasPrefix(strings.TrimSpace(query), ".load ") || strings.TrimSpace(query) == ".load" {
-		path := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".load"))
-		path = strings.Trim(path, " \"'")
-		if path == "" {
-			fmt.Println("Usage: .load <file.prom>")
+	if strings.HasPrefix(trimmed, ".load ") || trimmed == ".load" {
+		if handled := handleAdhocLoad(trimmed, storage); handled {
 			return true
 		}
-		f, err := os.Open(path)
-		if err != nil {
-			fmt.Printf("Failed to open %s: %v\n", path, err)
-			return true
-		}
-		defer f.Close()
-		beforeMetrics := len(storage.metrics)
-		beforeSamples := 0
-		for _, ss := range storage.metrics {
-			beforeSamples += len(ss)
-		}
-		if err := storage.LoadFromReader(f); err != nil {
-			fmt.Printf("Failed to load metrics from %s: %v\n", path, err)
-			return true
-		}
-		afterMetrics := len(storage.metrics)
-		afterSamples := 0
-		for _, ss := range storage.metrics {
-			afterSamples += len(ss)
-		}
-		fmt.Printf("Loaded %s: +%d metrics, +%d samples (total: %d metrics, %d samples)\n", path, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
-
-		// Refresh metrics cache for autocompletion if using prompt backend
-		if refreshMetricsCache != nil {
-			refreshMetricsCache(storage)
-		}
-
-		return true
 	}
 
 	// Handle .pinat <time|now|remove>
-	if strings.HasPrefix(strings.TrimSpace(query), ".pinat") {
-		arg := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), ".pinat"))
-		arg = strings.Trim(arg, " \"'")
-		if arg == "" {
-			if pinnedEvalTime == nil {
-				fmt.Println("Pinned evaluation time: none")
-			} else {
-				fmt.Printf("Pinned evaluation time: %s\n", pinnedEvalTime.UTC().Format(time.RFC3339))
-			}
+	if strings.HasPrefix(trimmed, ".pinat") {
+		if handled := handleAdhocPinAt(trimmed, storage); handled {
 			return true
 		}
-		if strings.EqualFold(arg, "remove") {
-			pinnedEvalTime = nil
-			fmt.Println("Pinned evaluation time: removed")
+	}
+
+	// Handle .prom_scrape_range <PROM_API_URI> 'query' <start> <end> <step> [count] [delay]
+	if strings.HasPrefix(trimmed, ".prom_scrape_range") {
+		if handled := handleAdhocPromScrapeRangeCommand(trimmed, storage); handled {
 			return true
 		}
-		var t time.Time
-		var err error
-		if strings.EqualFold(arg, "now") {
-			t = time.Now()
-		} else {
-			t, err = parseEvalTime(arg)
-			if err != nil {
-				fmt.Printf("Invalid time %q: %v\n", arg, err)
-				return true
-			}
+	}
+
+	// Handle .prom_scrape <PROM_API_URI> 'query' [count] [delay]
+	if strings.HasPrefix(trimmed, ".prom_scrape") {
+		if handled := handleAdhocPromScrapeCommand(trimmed, storage); handled {
+			return true
 		}
-		pinnedEvalTime = &t
-		fmt.Printf("Pinned evaluation time: %s\n", t.UTC().Format(time.RFC3339))
-		return true
 	}
 
 	// Handle .scrape <URI> [metrics_regex] [count] [delay]
-	if strings.HasPrefix(strings.TrimSpace(query), ".scrape ") {
-		args := strings.Fields(strings.TrimSpace(query))
-		if len(args) < 2 {
-			fmt.Println("Usage: .scrape <URI> [metrics_regex] [count] [delay]")
-			fmt.Println("Examples: .scrape http://localhost:9100/metrics | .scrape http://localhost:9100/metrics '^(up|process_.*)$' 3 5s")
+	if strings.HasPrefix(trimmed, ".scrape ") {
+		if handled := handleAdhocScrape(trimmed, storage); handled {
 			return true
 		}
-		uri := args[1]
-		var regexStr string
-		count := 1
-		delay := 10 * time.Second
-		countSet := false
-		delaySet := false
-		for _, tok := range args[2:] {
-			if !countSet {
-				if n, err := strconv.Atoi(tok); err == nil {
-					count = n
-					if count < 1 {
-						count = 1
-					}
-					countSet = true
-					continue
-				}
-			}
-			if !delaySet {
-				if d, err := time.ParseDuration(tok); err == nil {
-					delay = d
-					if delay < 0 {
-						delay = 0
-					}
-					delaySet = true
-					continue
-				}
-			}
-			if regexStr == "" {
-				regexStr = strings.Trim(tok, "\"'")
-				continue
-			}
-		}
-		var re *regexp.Regexp
-		var reErr error
-		if strings.TrimSpace(regexStr) != "" {
-			re, reErr = regexp.Compile(regexStr)
-			if reErr != nil {
-				fmt.Printf("Invalid metrics_regex %q: %v\n", regexStr, reErr)
-				return true
-			}
-		}
-
-		client := &http.Client{Timeout: 60 * time.Second}
-		for i := 0; i < count; i++ {
-			beforeMetrics := len(storage.metrics)
-			beforeSamples := 0
-			for _, ss := range storage.metrics {
-				beforeSamples += len(ss)
-			}
-
-			resp, err := client.Get(uri)
-			if err != nil {
-				fmt.Printf("Failed to scrape %s: %v\n", uri, err)
-				return true
-			}
-			func() {
-				defer resp.Body.Close()
-				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-					fmt.Printf("Failed to scrape %s: HTTP %d\n", uri, resp.StatusCode)
-					return
-				}
-				if re != nil {
-					if err := storage.LoadFromReaderWithFilter(resp.Body, func(name string) bool { return re.MatchString(name) }); err != nil {
-						fmt.Printf("Failed to parse metrics from %s: %v\n", uri, err)
-						return
-					}
-				} else {
-					if err := storage.LoadFromReader(resp.Body); err != nil {
-						fmt.Printf("Failed to parse metrics from %s: %v\n", uri, err)
-						return
-					}
-				}
-			}()
-
-			afterMetrics := len(storage.metrics)
-			afterSamples := 0
-			for _, ss := range storage.metrics {
-				afterSamples += len(ss)
-			}
-			fmt.Printf("Scraped %s (%d/%d): +%d metrics, +%d samples (total: %d metrics, %d samples)\n",
-				uri, i+1, count, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
-
-			if i < count-1 && delay > 0 {
-				time.Sleep(delay)
-			}
-		}
-
-		// Refresh metrics cache for autocompletion if using prompt backend
-		if refreshMetricsCache != nil {
-			refreshMetricsCache(storage)
-		}
-
-		return true
 	}
 
 	// Handle .seed <metric> [steps=N] [step=1m]
-	if strings.HasPrefix(query, ".seed ") {
-		args := strings.Fields(query)
-		if len(args) < 2 {
-			fmt.Println("Usage: .seed <metric> [steps=N] [step=1m]")
+	if strings.HasPrefix(trimmed, ".seed ") {
+		if handled := handleAdhocSeed(trimmed, storage); handled {
 			return true
 		}
-		metric := args[1]
-		steps := 5
-		step := time.Minute
-		posIdx := 0
-		for _, a := range args[2:] {
-			if strings.HasPrefix(a, "steps=") {
-				fmt.Sscanf(a, "steps=%d", &steps)
-				continue
-			}
-			if strings.HasPrefix(a, "step=") {
-				v := strings.TrimPrefix(a, "step=")
-				if d, err := time.ParseDuration(v); err == nil {
-					step = d
-				}
-				continue
-			}
-			// Positional parsing: first bare token -> steps (int), second -> step (duration)
-			if posIdx == 0 {
-				if n, err := strconv.Atoi(a); err == nil {
-					steps = n
-					posIdx++
-					continue
-				}
-			}
-			if posIdx <= 1 { // allow step to be set even if steps was invalid
-				if d, err := time.ParseDuration(a); err == nil {
-					step = d
-					posIdx = 2
-					continue
-				}
-			}
-		}
-		seedHistory(storage, metric, steps, step)
-		fmt.Printf("Seeded %d historical points (step %s) for metric '%s'\n", steps, step, metric)
-
-		// Refresh metrics cache for autocompletion if using prompt backend
-		if refreshMetricsCache != nil {
-			refreshMetricsCache(storage)
-		}
-
-		return true
 	}
 
 	return false
@@ -747,76 +152,4 @@ func handleHelpCommand() {
 		}
 	}
 	fmt.Println()
-}
-
-// handleLabelsCommand handles the .labels command
-func handleLabelsCommand(query string, storage *SimpleStorage) bool {
-	if !strings.HasPrefix(query, ".labels ") && !(strings.HasPrefix(query, ".labels(") && strings.HasSuffix(query, ")")) {
-		return false
-	}
-
-	var metric string
-	if strings.HasPrefix(query, ".labels ") {
-		metric = strings.TrimSpace(strings.TrimPrefix(query, ".labels "))
-	} else {
-		// Handle .labels(metric_name) format
-		metric = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(query, ".labels("), ")"))
-	}
-
-	if metric == "" {
-		fmt.Println("Usage: .labels <metric>")
-		return true
-	}
-
-	samples, exists := storage.metrics[metric]
-	if !exists {
-		fmt.Printf("Metric %s not found\n", metric)
-		return true
-	}
-
-	// Collect all unique label keys and sample values for each
-	labelInfo := make(map[string]map[string]bool)
-	for _, sample := range samples {
-		for labelName, labelValue := range sample.Labels {
-			if labelName == "__name__" {
-				continue
-			}
-			if labelInfo[labelName] == nil {
-				labelInfo[labelName] = make(map[string]bool)
-			}
-			labelInfo[labelName][labelValue] = true
-		}
-	}
-
-	if len(labelInfo) == 0 {
-		fmt.Printf("No labels found for metric %s\n", metric)
-		return true
-	}
-
-	// Sort label names
-	var labelNames []string
-	for labelName := range labelInfo {
-		labelNames = append(labelNames, labelName)
-	}
-	sort.Strings(labelNames)
-
-	fmt.Printf("Labels for metric %s:\n", metric)
-	for _, labelName := range labelNames {
-		values := labelInfo[labelName]
-		var valueList []string
-		for value := range values {
-			valueList = append(valueList, value)
-		}
-		sort.Strings(valueList)
-
-		// Show up to 5 example values
-		displayValues := valueList
-		if len(displayValues) > 5 {
-			displayValues = displayValues[:5]
-			fmt.Printf("  %s: %s ... (%d total values)\n", labelName, strings.Join(displayValues, ", "), len(valueList))
-		} else {
-			fmt.Printf("  %s: %s\n", labelName, strings.Join(displayValues, ", "))
-		}
-	}
-	return true
 }

--- a/adhoc_commands.go
+++ b/adhoc_commands.go
@@ -75,6 +75,24 @@ var AdHocCommands = []AdHocCommand{
 		},
 	},
 	{
+		Command:     ".prom_scrape",
+		Description: "Query a remote Prometheus API and import the results",
+		Usage:       ".prom_scrape <PROM_API_URI> 'query' [count] [delay]",
+		Examples: []string{
+			".prom_scrape http://localhost:9090/api/v1 'up'",
+			".prom_scrape http://localhost:9090 'rate(http_requests_total[5m])' 3 10s",
+		},
+	},
+	{
+		Command:     ".prom_scrape_range",
+		Description: "Query a remote Prometheus API over a time range and import the results",
+		Usage:       ".prom_scrape_range <PROM_API_URI> 'query' <start> <end> <step> [count] [delay]",
+		Examples: []string{
+			".prom_scrape_range http://localhost:9090 'up' now-15m now 30s",
+			".prom_scrape_range http://localhost:9090 'rate(http_requests_total[5m])' 2025-09-27T00:00:00Z 2025-09-27T00:30:00Z 15s",
+		},
+	},
+	{
 		Command:     ".drop",
 		Description: "Remove a metric from the in-memory store",
 		Usage:       ".drop <metric>",

--- a/adhoc_handle_ai.go
+++ b/adhoc_handle_ai.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+func handleAdhocAI(query string, storage *SimpleStorage) bool {
+	args := strings.TrimSpace(strings.TrimPrefix(query, ".ai"))
+	if args == "" || args == "help" { // help
+		fmt.Println("Usage: .ai <intent> | .ai ask <intent> | .ai show | .ai <N> | .ai run <N> | .ai edit <N>")
+		fmt.Println("Examples:")
+		fmt.Println("  .ai top 5 pods by http error rate over last hour")
+		fmt.Println("  .ai 1        # run suggestion [1] if available")
+		fmt.Println("  .ai show     # reprint last suggestions")
+		return true
+	}
+	// Selection: .ai show
+	if args == "show" {
+		if len(lastAISuggestions) == 0 {
+			fmt.Println("No AI suggestions yet. Try: .ai <intent>")
+			return true
+		}
+		// Activate the inline AI selection workflow (same as post-ask)
+		aiSelectionActive = true
+		fmt.Println("AI suggestions (valid PromQL):")
+		for i, s := range lastAISuggestions {
+			fmt.Printf("  [%d] %s\n", i+1, s)
+			if i < len(lastAIExplanations) {
+				if ex := strings.TrimSpace(lastAIExplanations[i]); ex != "" {
+					fmt.Printf("      - %s\n", ex)
+				}
+			}
+		}
+		fmt.Println("Choose with: .ai edit <N>  or  .ai run <N>  (1-based)")
+		fmt.Println("Tips: use Tab to open the dropdown and pick an item.")
+		return true
+	}
+	// Selection: .ai run N or .ai N
+	if strings.HasPrefix(args, "run ") || regexp.MustCompile(`^\d+$`).MatchString(args) {
+		var idxStr string
+		if strings.HasPrefix(args, "run ") {
+			idxStr = strings.TrimSpace(strings.TrimPrefix(args, "run "))
+		} else {
+			idxStr = args
+		}
+		n, err := strconv.Atoi(idxStr)
+		if err != nil || n <= 0 {
+			fmt.Println("Usage: .ai run <N>  (N is 1-based)")
+			return true
+		}
+		if len(lastAISuggestions) == 0 {
+			fmt.Println("No AI suggestions yet. Try: .ai <intent>")
+			return true
+		}
+		if n > len(lastAISuggestions) {
+			fmt.Printf("Only %d suggestions available\n", len(lastAISuggestions))
+			return true
+		}
+		pendingAISuggestion = lastAISuggestions[n-1]
+		fmt.Printf("Running suggestion [%d]: %s\n", n, pendingAISuggestion)
+		return true
+	}
+	// Selection: .ai edit N
+	if strings.HasPrefix(args, "edit ") {
+		idxStr := strings.TrimSpace(strings.TrimPrefix(args, "edit "))
+		n, err := strconv.Atoi(idxStr)
+		if err != nil || n <= 0 {
+			fmt.Println("Usage: .ai edit <N>  (N is 1-based)")
+			return true
+		}
+		if len(lastAISuggestions) == 0 {
+			fmt.Println("No AI suggestions yet. Try: .ai <intent>")
+			return true
+		}
+		if n > len(lastAISuggestions) {
+			fmt.Printf("Only %d suggestions available\n", len(lastAISuggestions))
+			return true
+		}
+		aiClipboard = lastAISuggestions[n-1]
+		fmt.Printf("Prepared suggestion [%d] for editing. Press Ctrl-Y to paste.\n", n)
+		return true
+	}
+	// Guard: ".ai run" or ".ai edit" without index should not call AI, show usage instead
+	if args == "run" || strings.HasPrefix(args, "run\t") || strings.HasSuffix(args, "run ") {
+		fmt.Println("Usage: .ai run <N>  (N is 1-based)")
+		return true
+	}
+	if args == "edit" || strings.HasPrefix(args, "edit\t") || strings.HasSuffix(args, "edit ") {
+		fmt.Println("Usage: .ai edit <N>  (N is 1-based)")
+		return true
+	}
+	// Support alias: .ai ask <intent>
+	if strings.HasPrefix(args, "ask ") {
+		args = strings.TrimSpace(strings.TrimPrefix(args, "ask "))
+	}
+	// Start AI request asynchronously so Ctrl-C can cancel it while the prompt remains responsive
+	if aiInProgress || aiCancelRequest != nil {
+		fmt.Println("AI request already in progress. Press Ctrl-C to cancel it.")
+		return true
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	aiCancelRequest = cancel
+	aiInProgress = true
+	fmt.Println("Asking AI... (press Ctrl-C to cancel)")
+	go func(intent string) {
+		defer func() {
+			aiInProgress = false
+			aiCancelRequest = nil
+			cancel()
+		}()
+		suggestions, err := aiSuggestQueriesCtx(ctx, storage, intent)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || strings.Contains(strings.ToLower(err.Error()), "context canceled") || strings.Contains(strings.ToLower(err.Error()), "request canceled") {
+				fmt.Println("AI request canceled")
+				return
+			}
+			fmt.Printf("AI error: %v\n", err)
+			return
+		}
+		var validQ []string
+		var validE []string
+		for _, sug := range suggestions {
+			q := strings.TrimSpace(sug.Query)
+			if q == "" {
+				continue
+			}
+			q = cleanCandidate(q)
+			if q == "" {
+				continue
+			}
+			if _, err := promparser.ParseExpr(q); err == nil {
+				validQ = append(validQ, q)
+				validE = append(validE, strings.TrimSpace(sug.Explain))
+			}
+		}
+		if len(validQ) == 0 {
+			fmt.Println("AI returned no valid PromQL suggestions.")
+			return
+		}
+		lastAISuggestions = validQ
+		lastAIExplanations = validE
+		aiSelectionActive = true
+		fmt.Println("AI suggestions (valid PromQL):")
+		for i := range validQ {
+			fmt.Printf("  [%d] %s\n", i+1, validQ[i])
+			if ex := strings.TrimSpace(validE[i]); ex != "" {
+				fmt.Printf("      - %s\n", ex)
+			}
+		}
+		fmt.Println("Choose with: .ai edit <N>  or  .ai run <N>  (1-based)")
+		fmt.Println("Tips: Alt-1..Alt-9 to paste a suggestion; Ctrl-Y to paste the first suggestion.")
+	}(args)
+	// Return immediately to keep the prompt interactive
+	return true
+}

--- a/adhoc_handle_file.go
+++ b/adhoc_handle_file.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func handleAdhocHistory(query string, storage *SimpleStorage) bool {
+	fields := strings.Fields(query)
+	var n int = -1
+	if len(fields) == 2 {
+		if v, err := strconv.Atoi(fields[1]); err == nil && v > 0 {
+			n = v
+		} else {
+			fmt.Println("Usage: .history [N]")
+			return true
+		}
+	} else if len(fields) > 2 {
+		fmt.Println("Usage: .history [N]")
+		return true
+	}
+	// Prefer in-memory history when available (prompt backend)
+	entries := getInMemoryHistory()
+	if len(entries) == 0 {
+		// Fallback to file
+		path := getHistoryFilePath()
+		entries = loadHistoryFromFile(path)
+	}
+	if len(entries) == 0 {
+		fmt.Println("No history available")
+		return true
+	}
+	start := 0
+	if n > 0 && n < len(entries) {
+		start = len(entries) - n
+	}
+	for i := start; i < len(entries); i++ {
+		fmt.Println(entries[i])
+	}
+	return true
+}
+
+func handleAdhocSave(query string, storage *SimpleStorage) bool {
+	path := strings.TrimSpace(strings.TrimPrefix(query, ".save"))
+	path = strings.Trim(path, " \"'")
+	if path == "" {
+		fmt.Println("Usage: .save <file.prom>")
+		return true
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Printf("Failed to open %s for writing: %v\n", path, err)
+		return true
+	}
+	defer f.Close()
+	if err := storage.SaveToWriter(f); err != nil {
+		fmt.Printf("Failed to save metrics to %s: %v\n", path, err)
+		return true
+	}
+	fmt.Printf("Saved store to %s\n", path)
+	return true
+}
+
+func handleAdhocLoad(query string, storage *SimpleStorage) bool {
+	path := strings.TrimSpace(strings.TrimPrefix(query, ".load"))
+	path = strings.Trim(path, " \"'")
+	if path == "" {
+		fmt.Println("Usage: .load <file.prom>")
+		return true
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Printf("Failed to open %s: %v\n", path, err)
+		return true
+	}
+	defer f.Close()
+	beforeMetrics := len(storage.metrics)
+	beforeSamples := 0
+	for _, ss := range storage.metrics {
+		beforeSamples += len(ss)
+	}
+	if err := storage.LoadFromReader(f); err != nil {
+		fmt.Printf("Failed to load metrics from %s: %v\n", path, err)
+		return true
+	}
+	afterMetrics := len(storage.metrics)
+	afterSamples := 0
+	for _, ss := range storage.metrics {
+		afterSamples += len(ss)
+	}
+	fmt.Printf("Loaded %s: +%d metrics, +%d samples (total: %d metrics, %d samples)\n", path, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
+
+	// Refresh metrics cache for autocompletion if using prompt backend
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+
+	return true
+}

--- a/adhoc_handle_http.go
+++ b/adhoc_handle_http.go
@@ -1,0 +1,737 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// promAPIResponse is a minimal struct to parse Prometheus HTTP API responses (vector/matrix/scalar)
+type promAPIResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string          `json:"resultType"`
+		Result     []promAPISeries `json:"result"`
+	} `json:"data"`
+	Error     string `json:"error"`
+	ErrorType string `json:"errorType"`
+}
+
+// promAPISeries represents one series in the result
+type promAPISeries struct {
+	Metric map[string]string `json:"metric"`
+	Value  [2]any            `json:"value"`  // vector/scalar
+	Values [][2]any          `json:"values"` // matrix
+}
+
+func handleAdhocScrape(query string, storage *SimpleStorage) bool {
+	args := strings.Fields(query)
+	if len(args) < 2 {
+		fmt.Println("Usage: .scrape <URI> [metrics_regex] [count] [delay]")
+		fmt.Println("Examples: .scrape http://localhost:9100/metrics | .scrape http://localhost:9100/metrics '^(up|process_.*)$' 3 5s")
+		return true
+	}
+	uri := args[1]
+	var regexStr string
+	count := 1
+	delay := 10 * time.Second
+	countSet := false
+	delaySet := false
+	for _, tok := range args[2:] {
+		if !countSet {
+			if n, err := strconv.Atoi(tok); err == nil {
+				count = n
+				if count < 1 {
+					count = 1
+				}
+				countSet = true
+				continue
+			}
+		}
+		if !delaySet {
+			if d, err := time.ParseDuration(tok); err == nil {
+				delay = d
+				if delay < 0 {
+					delay = 0
+				}
+				delaySet = true
+				continue
+			}
+		}
+		if regexStr == "" {
+			regexStr = strings.Trim(tok, "\"'")
+			continue
+		}
+	}
+	var re *regexp.Regexp
+	var reErr error
+	if strings.TrimSpace(regexStr) != "" {
+		re, reErr = regexp.Compile(regexStr)
+		if reErr != nil {
+			fmt.Printf("Invalid metrics_regex %q: %v\n", regexStr, reErr)
+			return true
+		}
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	for i := 0; i < count; i++ {
+		beforeMetrics := len(storage.metrics)
+		beforeSamples := 0
+		for _, ss := range storage.metrics {
+			beforeSamples += len(ss)
+		}
+
+		resp, err := client.Get(uri)
+		if err != nil {
+			fmt.Printf("Failed to scrape %s: %v\n", uri, err)
+			return true
+		}
+		func() {
+			defer resp.Body.Close()
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				fmt.Printf("Failed to scrape %s: HTTP %d\n", uri, resp.StatusCode)
+				return
+			}
+			if re != nil {
+				if err := storage.LoadFromReaderWithFilter(resp.Body, func(name string) bool { return re.MatchString(name) }); err != nil {
+					fmt.Printf("Failed to parse metrics from %s: %v\n", uri, err)
+					return
+				}
+			} else {
+				if err := storage.LoadFromReader(resp.Body); err != nil {
+					fmt.Printf("Failed to parse metrics from %s: %v\n", uri, err)
+					return
+				}
+			}
+		}()
+
+		afterMetrics := len(storage.metrics)
+		afterSamples := 0
+		for _, ss := range storage.metrics {
+			afterSamples += len(ss)
+		}
+		fmt.Printf("Scraped %s (%d/%d): +%d metrics, +%d samples (total: %d metrics, %d samples)\n",
+			uri, i+1, count, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
+
+		if i < count-1 && delay > 0 {
+			time.Sleep(delay)
+		}
+	}
+
+	// Refresh metrics cache for autocompletion if using prompt backend
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+
+	return true
+}
+
+// handleAdhocPromScrapeCommand parses and executes .prom_scrape, importing results from a remote Prometheus API.
+// Syntax: .prom_scrape <PROM_API_URI> 'query' [count] [delay]
+func handleAdhocPromScrapeCommand(input string, storage *SimpleStorage) bool {
+	trim := strings.TrimSpace(input)
+	if !strings.HasPrefix(trim, ".prom_scrape") {
+		return false
+	}
+	// Remove command token
+	rest := strings.TrimSpace(strings.TrimPrefix(trim, ".prom_scrape"))
+	if rest == "" {
+		fmt.Println("Usage: .prom_scrape <PROM_API_URI> 'query' [count] [delay] [auth=basic|mimir] [user=...] [pass=...] [org_id=...] [api_key=...]")
+		return true
+	}
+	// Parse: URI, quoted or unquoted query, optional N and DELAY + auth KVs
+	uri, q, count, delay, authMode, user, pass, orgID, apiKey, err := parsePromScrapeArgs(rest)
+	if err != nil {
+		fmt.Printf(".prom_scrape: %v\n", err)
+		fmt.Println("Usage: .prom_scrape <PROM_API_URI> 'query' [count] [delay] [auth=basic|mimir] [user=...] [pass=...] [org_id=...] [api_key=...]")
+		return true
+	}
+	if count <= 0 {
+		count = 1
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	endpoint := buildPromQueryEndpoint(uri)
+	for i := 0; i < count; i++ {
+		// Build GET request to /api/v1/query?query=...
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			fmt.Printf("Invalid PROM_API_URI %q: %v\n", uri, err)
+			return true
+		}
+		qv := u.Query()
+		qv.Set("query", q)
+		u.RawQuery = qv.Encode()
+		req, _ := http.NewRequest("GET", u.String(), nil)
+		// Apply auth
+		applyPromAuth(req, authMode, user, pass, orgID, apiKey)
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Printf("Prometheus API request failed: %v\n", err)
+			return true
+		}
+		func() {
+			defer resp.Body.Close()
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				fmt.Printf("Prometheus API HTTP %d\n", resp.StatusCode)
+				return
+			}
+			var pr promAPIResponse
+			if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+				fmt.Printf("Failed to decode Prometheus API response: %v\n", err)
+				return
+			}
+			if strings.ToLower(pr.Status) != "success" {
+				if pr.Error != "" {
+					fmt.Printf("Prometheus API error: %s (%s)\n", pr.Error, pr.ErrorType)
+				} else {
+					fmt.Printf("Prometheus API returned non-success status: %s\n", pr.Status)
+				}
+				return
+			}
+			// Import results
+			added := importPromResultIntoStorage(storage, &pr)
+			afterMetrics := len(storage.metrics)
+			afterSamples := 0
+			for _, ss := range storage.metrics {
+				afterSamples += len(ss)
+			}
+			fmt.Printf("Imported from %s (%d/%d): +%d samples (total: %d metrics, %d samples)\n",
+				u.Scheme+"://"+u.Host, i+1, count, added, afterMetrics, afterSamples)
+		}()
+
+		if i < count-1 && delay > 0 {
+			time.Sleep(delay)
+		}
+	}
+
+	// Refresh metrics cache for autocompletion if using prompt backend
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+
+	return true
+}
+
+// applyPromAuth sets HTTP headers based on auth mode and provided values.
+func applyPromAuth(req *http.Request, authMode, user, pass, orgID, apiKey string) {
+	mode := strings.ToLower(strings.TrimSpace(authMode))
+	// Infer mode if not set
+	if mode == "" {
+		if user != "" || pass != "" {
+			mode = "basic"
+		} else if orgID != "" || apiKey != "" {
+			mode = "mimir"
+		}
+	}
+	switch mode {
+	case "basic":
+		if user != "" || pass != "" {
+			req.SetBasicAuth(user, pass)
+		}
+	case "mimir":
+		if orgID != "" {
+			req.Header.Set("X-Scope-OrgID", orgID)
+		}
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+	default:
+		// no auth
+	}
+}
+
+// importPromResultIntoStorage converts the API response into samples and appends them to storage.
+// Returns number of samples added.
+func importPromResultIntoStorage(storage *SimpleStorage, pr *promAPIResponse) int {
+	added := 0
+	typeLower := strings.ToLower(pr.Data.ResultType)
+	switch typeLower {
+	case "vector":
+		for _, s := range pr.Data.Result {
+			value, ok1 := parsePromValue(s.Value[1])
+			tsMs, ok2 := parsePromTimestampMillis(s.Value[0])
+			if !ok1 || !ok2 {
+				continue
+			}
+			labels := s.Metric
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			if labels["__name__"] == "" {
+				labels["__name__"] = "query_result"
+			}
+			storage.AddSample(labels, value, tsMs)
+			added++
+		}
+	case "matrix":
+		for _, s := range pr.Data.Result {
+			labels := s.Metric
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			if labels["__name__"] == "" {
+				labels["__name__"] = "query_result"
+			}
+			for _, pair := range s.Values {
+				v, ok1 := parsePromValue(pair[1])
+				tsMs, ok2 := parsePromTimestampMillis(pair[0])
+				if !ok1 || !ok2 {
+					continue
+				}
+				storage.AddSample(labels, v, tsMs)
+				added++
+			}
+		}
+	case "scalar":
+		if len(pr.Data.Result) == 0 {
+			return 0
+		}
+		v, ok1 := parsePromValue(pr.Data.Result[0].Value[1])
+		tsMs, ok2 := parsePromTimestampMillis(pr.Data.Result[0].Value[0])
+		if ok1 && ok2 {
+			labels := map[string]string{"__name__": "query_result"}
+			storage.AddSample(labels, v, tsMs)
+			added++
+		}
+	default:
+		// unsupported type
+	}
+	return added
+}
+
+func parsePromValue(x any) (float64, bool) {
+	switch v := x.(type) {
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		return f, err == nil
+	case float64:
+		return v, true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func parsePromTimestampMillis(x any) (int64, bool) {
+	switch v := x.(type) {
+	case float64:
+		return int64(v * 1000.0), true
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, false
+		}
+		return int64(f * 1000.0), true
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return int64(f * 1000.0), true
+	default:
+		return 0, false
+	}
+}
+
+// buildPromQueryEndpoint tries to construct a /api/v1/query endpoint from a base URI.
+func buildPromQueryEndpoint(base string) string {
+	b := strings.TrimRight(base, "/")
+	//return b + "query"
+	if strings.HasSuffix(b, "/query") {
+		return b
+	}
+	if strings.HasSuffix(b, "/api/v1") {
+		return b + "/query"
+	}
+	if strings.Contains(b, "/api/v1/") {
+		// Assume it's already under /api/v1; append query if needed
+		if strings.HasSuffix(b, "/") {
+			return b + "query"
+		}
+		return b + "/query"
+	}
+	return b + "/api/v1/query"
+}
+
+// buildPromQueryRangeEndpoint tries to construct a /api/v1/query_range endpoint from a base URI.
+func buildPromQueryRangeEndpoint(base string) string {
+	b := strings.TrimRight(base, "/")
+	if strings.HasSuffix(b, "/query_range") {
+		return b
+	}
+	if strings.HasSuffix(b, "/api/v1") {
+		return b + "/query_range"
+	}
+	if strings.Contains(b, "/api/v1/") {
+		if strings.HasSuffix(b, "/") {
+			return b + "query_range"
+		}
+		return b + "/query_range"
+	}
+	return b + "/api/v1/query_range"
+}
+
+// parsePromScrapeArgs parses rest of the command after .prom_scrape
+func parsePromScrapeArgs(rest string) (uri string, query string, count int, delay time.Duration, authMode, user, pass, orgID, apiKey string, err error) {
+	i := 0
+	skipSpaces := func() {
+		for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t') {
+			i++
+		}
+	}
+	nextToken := func() (string, bool) {
+		if i >= len(rest) {
+			return "", false
+		}
+		start := i
+		for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+			i++
+		}
+		return rest[start:i], true
+	}
+	skipSpaces()
+	// URI: read until space
+	start := i
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	if i == start {
+		err = fmt.Errorf("missing PROM_API_URI")
+		return
+	}
+	uri = rest[start:i]
+	skipSpaces()
+	if i >= len(rest) {
+		err = fmt.Errorf("missing query expression")
+		return
+	}
+	// Query: quoted or unquoted token
+	if rest[i] == '\'' || rest[i] == '"' {
+		quote := rest[i]
+		i++
+		qStart := i
+		for i < len(rest) {
+			if rest[i] == quote {
+				break
+			}
+			i++
+		}
+		if i >= len(rest) {
+			err = fmt.Errorf("unterminated quoted query")
+			return
+		}
+		query = rest[qStart:i]
+		i++ // skip closing quote
+	} else {
+		qStart := i
+		for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+			i++
+		}
+		query = rest[qStart:i]
+	}
+	skipSpaces()
+	// Optional count
+	count = 1
+	delay = 0
+	if i < len(rest) {
+		// Try integer
+		j := i
+		for j < len(rest) && rest[j] != ' ' && rest[j] != '\t' {
+			j++
+		}
+		if n, errN := strconv.Atoi(rest[i:j]); errN == nil {
+			count = n
+			i = j
+			skipSpaces()
+		}
+	}
+	// Optional delay
+	if i < len(rest) {
+		j := i
+		for j < len(rest) && rest[j] != ' ' && rest[j] != '\t' {
+			j++
+		}
+		if d, errD := time.ParseDuration(rest[i:j]); errD == nil {
+			delay = d
+			i = j
+			skipSpaces()
+		}
+	}
+	// Optional auth key=value tokens
+	for {
+		skipSpaces()
+		tok, ok := nextToken()
+		if !ok || tok == "" {
+			break
+		}
+		if eq := strings.IndexByte(tok, '='); eq > 0 {
+			k := strings.ToLower(strings.TrimSpace(tok[:eq]))
+			v := strings.TrimSpace(tok[eq+1:])
+			switch k {
+			case "auth", "auth_mode":
+				authMode = strings.ToLower(v)
+			case "user", "username":
+				user = v
+			case "pass", "password":
+				pass = v
+			case "org_id", "orgid", "tenant", "tenant_id":
+				orgID = v
+			case "api_key", "apikey":
+				apiKey = v
+			}
+		}
+	}
+	return
+}
+
+// handleAdhocPromScrapeRangeCommand parses and executes .prom_scrape_range, importing results via query_range.
+// Syntax: .prom_scrape_range <PROM_API_URI> 'query' <start> <end> <step> [count] [delay]
+func handleAdhocPromScrapeRangeCommand(input string, storage *SimpleStorage) bool {
+	trim := strings.TrimSpace(input)
+	if !strings.HasPrefix(trim, ".prom_scrape_range") {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(trim, ".prom_scrape_range"))
+	if rest == "" {
+		fmt.Println("Usage: .prom_scrape_range <PROM_API_URI> 'query' <start> <end> <step> [count] [delay] [auth=basic|mimir] [user=...] [pass=...] [org_id=...] [api_key=...]")
+		return true
+	}
+	uri, q, start, end, step, count, delay, authMode, user, pass, orgID, apiKey, err := parsePromScrapeRangeArgs(rest)
+	if err != nil {
+		fmt.Printf(".prom_scrape_range: %v\n", err)
+		fmt.Println("Usage: .prom_scrape_range <PROM_API_URI> 'query' <start> <end> <step> [count] [delay] [auth=basic|mimir] [user=...] [pass=...] [org_id=...] [api_key=...]")
+		return true
+	}
+	if count <= 0 {
+		count = 1
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	endpoint := buildPromQueryRangeEndpoint(uri)
+	for i := 0; i < count; i++ {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			fmt.Printf("Invalid PROM_API_URI %q: %v\n", uri, err)
+			return true
+		}
+		qv := u.Query()
+		qv.Set("query", q)
+		qv.Set("start", start.UTC().Format(time.RFC3339))
+		qv.Set("end", end.UTC().Format(time.RFC3339))
+		qv.Set("step", step.String())
+		u.RawQuery = qv.Encode()
+		req, _ := http.NewRequest("GET", u.String(), nil)
+		applyPromAuth(req, authMode, user, pass, orgID, apiKey)
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Printf("Prometheus API request failed: %v\n", err)
+			return true
+		}
+		func() {
+			defer resp.Body.Close()
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				fmt.Printf("Prometheus API HTTP %d\n", resp.StatusCode)
+				return
+			}
+			var pr promAPIResponse
+			if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+				fmt.Printf("Failed to decode Prometheus API response: %v\n", err)
+				return
+			}
+			if strings.ToLower(pr.Status) != "success" {
+				if pr.Error != "" {
+					fmt.Printf("Prometheus API error: %s (%s)\n", pr.Error, pr.ErrorType)
+				} else {
+					fmt.Printf("Prometheus API returned non-success status: %s\n", pr.Status)
+				}
+				return
+			}
+			added := importPromResultIntoStorage(storage, &pr)
+			afterMetrics := len(storage.metrics)
+			afterSamples := 0
+			for _, ss := range storage.metrics {
+				afterSamples += len(ss)
+			}
+			fmt.Printf("Imported range from %s (%d/%d): +%d samples (total: %d metrics, %d samples)\n",
+				u.Scheme+"://"+u.Host, i+1, count, added, afterMetrics, afterSamples)
+		}()
+
+		if i < count-1 && delay > 0 {
+			time.Sleep(delay)
+		}
+	}
+
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+	return true
+}
+
+// parsePromScrapeRangeArgs parses the args after .prom_scrape_range
+func parsePromScrapeRangeArgs(rest string) (uri string, query string, start time.Time, end time.Time, step time.Duration, count int, delay time.Duration, authMode, user, pass, orgID, apiKey string, err error) {
+	i := 0
+	skipSpaces := func() {
+		for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t') {
+			i++
+		}
+	}
+	skipSpaces()
+	// URI token
+	startIdx := i
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	if i == startIdx {
+		err = fmt.Errorf("missing PROM_API_URI")
+		return
+	}
+	uri = rest[startIdx:i]
+	skipSpaces()
+	// Query token (quoted or unquoted)
+	if i >= len(rest) {
+		err = fmt.Errorf("missing query expression")
+		return
+	}
+	if rest[i] == '\'' || rest[i] == '"' {
+		quote := rest[i]
+		i++
+		qStart := i
+		for i < len(rest) {
+			if rest[i] == quote {
+				break
+			}
+			i++
+		}
+		if i >= len(rest) {
+			err = fmt.Errorf("unterminated quoted query")
+			return
+		}
+		query = rest[qStart:i]
+		i++
+	} else {
+		qStart := i
+		for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+			i++
+		}
+		query = rest[qStart:i]
+	}
+	skipSpaces()
+	// start time
+	if i >= len(rest) {
+		err = fmt.Errorf("missing start time")
+		return
+	}
+	sStart := i
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	startStr := rest[sStart:i]
+	start, err = parseEvalTime(startStr)
+	if err != nil {
+		err = fmt.Errorf("invalid start time %q: %v", startStr, err)
+		return
+	}
+	skipSpaces()
+	// end time
+	if i >= len(rest) {
+		err = fmt.Errorf("missing end time")
+		return
+	}
+	eStart := i
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	endStr := rest[eStart:i]
+	end, err = parseEvalTime(endStr)
+	if err != nil {
+		err = fmt.Errorf("invalid end time %q: %v", endStr, err)
+		return
+	}
+	skipSpaces()
+	// step duration
+	if i >= len(rest) {
+		err = fmt.Errorf("missing step duration")
+		return
+	}
+	stStart := i
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	stepStr := rest[stStart:i]
+	step, err = time.ParseDuration(stepStr)
+	if err != nil {
+		err = fmt.Errorf("invalid step duration %q: %v", stepStr, err)
+		return
+	}
+	skipSpaces()
+	// optional count
+	count = 1
+	delay = 0
+	if i < len(rest) {
+		j := i
+		for j < len(rest) && rest[j] != ' ' && rest[j] != '\t' {
+			j++
+		}
+		if n, errN := strconv.Atoi(rest[i:j]); errN == nil {
+			count = n
+			i = j
+			skipSpaces()
+		}
+	}
+	// optional delay
+	if i < len(rest) {
+		j := i
+		for j < len(rest) && rest[j] != ' ' && rest[j] != '\t' {
+			j++
+		}
+		if d, errD := time.ParseDuration(rest[i:j]); errD == nil {
+			delay = d
+			i = j
+			skipSpaces()
+		}
+	}
+	// optional auth KV tokens
+	for i < len(rest) {
+		// read token
+		startTok := i
+		for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+			i++
+		}
+		tok := rest[startTok:i]
+		skipSpaces()
+		if tok == "" {
+			break
+		}
+		if eq := strings.IndexByte(tok, '='); eq > 0 {
+			k := strings.ToLower(strings.TrimSpace(tok[:eq]))
+			v := strings.TrimSpace(tok[eq+1:])
+			switch k {
+			case "auth", "auth_mode":
+				authMode = strings.ToLower(v)
+			case "user", "username":
+				user = v
+			case "pass", "password":
+				pass = v
+			case "org_id", "orgid", "tenant", "tenant_id":
+				orgID = v
+			case "api_key", "apikey":
+				apiKey = v
+			}
+		}
+	}
+	return
+}

--- a/adhoc_handle_metrics.go
+++ b/adhoc_handle_metrics.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func handleAdhocMetrics(query string, storage *SimpleStorage) bool {
+	if len(storage.metrics) == 0 {
+		fmt.Println("No metrics loaded")
+		return true
+	}
+	var names []string
+	for name := range storage.metrics {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	fmt.Printf("Metrics (%d):\n", len(names))
+	for _, n := range names {
+		fmt.Printf("  - %s\n", n)
+	}
+	return true
+}
+
+func handleAdhocLabels(query string, storage *SimpleStorage) bool {
+	var metricName string
+	if strings.HasPrefix(query, ".labels ") {
+		metricName = strings.TrimSpace(strings.TrimPrefix(query, ".labels "))
+	}
+	metricName = strings.Trim(metricName, " \"'")
+
+	if metricName == "" {
+		fmt.Println("Usage: .labels <metric_name>")
+		fmt.Println("Example: .labels cloudcost_azure_aks_storage_by_location_usd_per_gibyte_hour")
+		return true
+	}
+
+	// Check if metric exists
+	samples, exists := storage.metrics[metricName]
+	if !exists {
+		fmt.Printf("Metric '%s' not found\n", metricName)
+		fmt.Println("Available metrics:")
+		count := 0
+		for name := range storage.metrics {
+			if count >= 5 {
+				fmt.Printf("... and %d more\n", len(storage.metrics)-5)
+				break
+			}
+			fmt.Printf("  - %s\n", name)
+			count++
+		}
+		return true
+	}
+
+	// Collect all unique labels for this metric
+	labelNames := make(map[string]bool)
+	labelValues := make(map[string]map[string]bool)
+
+	for _, sample := range samples {
+		for labelName, labelValue := range sample.Labels {
+			if labelName != "__name__" { // Skip the metric name label
+				labelNames[labelName] = true
+
+				if labelValues[labelName] == nil {
+					labelValues[labelName] = make(map[string]bool)
+				}
+				labelValues[labelName][labelValue] = true
+			}
+		}
+	}
+
+	// Display results
+	fmt.Printf("Labels for metric '%s' (%d samples):\n", metricName, len(samples))
+	if len(labelNames) == 0 {
+		fmt.Println("  No labels found")
+		return true
+	}
+
+	// Sort label names for consistent output
+	var sortedLabels []string
+	for labelName := range labelNames {
+		sortedLabels = append(sortedLabels, labelName)
+	}
+	sort.Strings(sortedLabels)
+
+	for _, labelName := range sortedLabels {
+		values := labelValues[labelName]
+		valueCount := len(values)
+
+		fmt.Printf("  %s (%d values)", labelName, valueCount)
+
+		// Show first few values as examples
+		if valueCount > 0 {
+			var sortedValues []string
+			for value := range values {
+				sortedValues = append(sortedValues, value)
+			}
+			sort.Strings(sortedValues)
+
+			fmt.Printf(": ")
+			if valueCount <= 3 {
+				// Show all values if 3 or fewer
+				for i, value := range sortedValues {
+					if i > 0 {
+						fmt.Printf(", ")
+					}
+					fmt.Printf("%q", value)
+				}
+			} else {
+				// Show first 3 values and indicate there are more
+				for i := 0; i < 3; i++ {
+					if i > 0 {
+						fmt.Printf(", ")
+					}
+					fmt.Printf("%q", sortedValues[i])
+				}
+				fmt.Printf(", ... and %d more", valueCount-3)
+			}
+		}
+		fmt.Println()
+	}
+
+	return true
+}
+
+func handleAdhocTimestamps(query string, storage *SimpleStorage) bool {
+	metric := strings.TrimSpace(strings.TrimPrefix(query, ".timestamps"))
+	metric = strings.Trim(metric, " \"'")
+	if metric == "" {
+		fmt.Println("Usage: .timestamps <metric>")
+		fmt.Println("Example: .timestamps http_requests_total")
+		return true
+	}
+	samples, exists := storage.metrics[metric]
+	if !exists || len(samples) == 0 {
+		fmt.Printf("Metric '%s' not found or has no samples\n", metric)
+		return true
+	}
+	// Series count (group by labelset excluding __name__)
+	seriesSet := make(map[string]struct{})
+	for _, s := range samples {
+		// build key excluding __name__
+		keys := make([]string, 0, len(s.Labels))
+		for k := range s.Labels {
+			if k == "__name__" {
+				continue
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		b := strings.Builder{}
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteByte('\xff') // unlikely separator
+			}
+			b.WriteString(k)
+			b.WriteByte('=')
+			b.WriteString(s.Labels[k])
+		}
+		seriesSet[b.String()] = struct{}{}
+	}
+	seriesCount := len(seriesSet)
+
+	// Unique timestamps and min/max
+	uniq := make(map[int64]int)
+	var minTs, maxTs int64
+	first := true
+	for _, s := range samples {
+		uniq[s.Timestamp]++
+		if first {
+			minTs, maxTs = s.Timestamp, s.Timestamp
+			first = false
+		} else {
+			if s.Timestamp < minTs {
+				minTs = s.Timestamp
+			}
+			if s.Timestamp > maxTs {
+				maxTs = s.Timestamp
+			}
+		}
+	}
+	uniqueCount := len(uniq)
+	span := time.Duration(maxTs-minTs) * time.Millisecond
+	// Prepare example timestamps
+	ts := make([]int64, 0, uniqueCount)
+	for t := range uniq {
+		ts = append(ts, t)
+	}
+	sort.Slice(ts, func(i, j int) bool { return ts[i] < ts[j] })
+	exN := 5
+	if len(ts) < exN {
+		exN = len(ts)
+	}
+	fmt.Printf("Timestamp summary for metric '%s'\n", metric)
+	fmt.Printf("  Series: %d\n", seriesCount)
+	fmt.Printf("  Samples: %d\n", len(samples))
+	fmt.Printf("  Unique timestamps: %d\n", uniqueCount)
+	fmt.Printf("  Earliest: %s (unix_ms=%d)\n", time.UnixMilli(minTs).UTC().Format(time.RFC3339), minTs)
+	fmt.Printf("  Latest:   %s (unix_ms=%d)\n", time.UnixMilli(maxTs).UTC().Format(time.RFC3339), maxTs)
+	fmt.Printf("  Span:     %s\n", span)
+	if exN > 0 {
+		fmt.Printf("  Examples: ")
+		for i := 0; i < exN; i++ {
+			if i > 0 {
+				fmt.Printf(", ")
+			}
+			fmt.Printf("%s", time.UnixMilli(ts[i]).UTC().Format(time.RFC3339))
+		}
+		fmt.Println()
+	}
+	return true
+}
+
+func handleAdhocDrop(query string, storage *SimpleStorage) bool {
+	metric := strings.TrimSpace(strings.TrimPrefix(query, ".drop"))
+	metric = strings.TrimSpace(metric)
+	if metric == "" {
+		fmt.Println("Usage: .drop <metric>")
+		fmt.Println("Example: .drop http_requests_total")
+		return true
+	}
+	// Check existence
+	samples, exists := storage.metrics[metric]
+	if !exists {
+		fmt.Printf("Metric '%s' not found\n", metric)
+		return true
+	}
+	removed := len(samples)
+	delete(storage.metrics, metric)
+	// Report new totals
+	totalMetrics := len(storage.metrics)
+	totalSamples := 0
+	for _, ss := range storage.metrics {
+		totalSamples += len(ss)
+	}
+	fmt.Printf("Dropped '%s': -%d samples (now: %d metrics, %d samples)\n", metric, removed, totalMetrics, totalSamples)
+
+	// Refresh metrics cache for autocompletion if using prompt backend
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+
+	return true
+}
+
+func handleAdhocSeed(query string, storage *SimpleStorage) bool {
+	args := strings.Fields(query)
+	if len(args) < 2 {
+		fmt.Println("Usage: .seed <metric> [steps=N] [step=1m]")
+		return true
+	}
+	metric := args[1]
+	steps := 5
+	step := time.Minute
+	posIdx := 0
+	for _, a := range args[2:] {
+		if strings.HasPrefix(a, "steps=") {
+			fmt.Sscanf(a, "steps=%d", &steps)
+			continue
+		}
+		if strings.HasPrefix(a, "step=") {
+			v := strings.TrimPrefix(a, "step=")
+			if d, err := time.ParseDuration(v); err == nil {
+				step = d
+			}
+			continue
+		}
+		// Positional parsing: first bare token -> steps (int), second -> step (duration)
+		if posIdx == 0 {
+			if n, err := strconv.Atoi(a); err == nil {
+				steps = n
+				posIdx++
+				continue
+			}
+		}
+		if posIdx <= 1 { // allow step to be set even if steps was invalid
+			if d, err := time.ParseDuration(a); err == nil {
+				step = d
+				posIdx = 2
+				continue
+			}
+		}
+	}
+	seedHistory(storage, metric, steps, step)
+	fmt.Printf("Seeded %d historical points (step %s) for metric '%s'\n", steps, step, metric)
+
+	// Refresh metrics cache for autocompletion if using prompt backend
+	if refreshMetricsCache != nil {
+		refreshMetricsCache(storage)
+	}
+
+	return true
+}

--- a/adhoc_handle_time.go
+++ b/adhoc_handle_time.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func handleAdhocPinAt(query string, storage *SimpleStorage) bool {
+	arg := strings.TrimSpace(strings.TrimPrefix(query, ".pinat"))
+	arg = strings.Trim(arg, " \"'")
+	if arg == "" {
+		if pinnedEvalTime == nil {
+			fmt.Println("Pinned evaluation time: none")
+		} else {
+			fmt.Printf("Pinned evaluation time: %s\n", pinnedEvalTime.UTC().Format(time.RFC3339))
+		}
+		return true
+	}
+	if strings.EqualFold(arg, "remove") {
+		pinnedEvalTime = nil
+		fmt.Println("Pinned evaluation time: removed")
+		return true
+	}
+	var t time.Time
+	var err error
+	if strings.EqualFold(arg, "now") {
+		t = time.Now()
+	} else {
+		t, err = parseEvalTime(arg)
+		if err != nil {
+			fmt.Printf("Invalid time %q: %v\n", arg, err)
+			return true
+		}
+	}
+	pinnedEvalTime = &t
+	fmt.Printf("Pinned evaluation time: %s\n", t.UTC().Format(time.RFC3339))
+	return true
+}

--- a/prompt_repl.go
+++ b/prompt_repl.go
@@ -156,8 +156,8 @@ func promptCompleter(d prompt.Document) []prompt.Suggest {
 			return filtered
 		}
 
-		// Handle .scrape URL completions FIRST (before checking for other commands with metric completion)
-		if strings.HasPrefix(trimmedText, ".scrape") {
+		// Handle .scrape, .prom_scrape and .prom_scrape_range URL completions FIRST
+		if strings.HasPrefix(trimmedText, ".scrape") || strings.HasPrefix(trimmedText, ".prom_scrape") || strings.HasPrefix(trimmedText, ".prom_scrape_range") {
 			if strings.Contains(text, ".scrape ") {
 				cmdEnd := strings.Index(text, ".scrape ") + 8
 				afterCmd := strings.TrimSpace(text[cmdEnd:])

--- a/repl.go
+++ b/repl.go
@@ -459,8 +459,8 @@ func (pac *PrometheusAutoCompleter) getCompletions(line string, pos int, current
 			}
 			return pac.getFilePathCompletions(pathSoFar, currentWord)
 		}
-		// If after ".scrape ", offer URL examples
-		if strings.HasPrefix(trimmed, ".scrape ") {
+		// If after ".scrape ", ".prom_scrape ", or ".prom_scrape_range ", offer URL examples
+		if strings.HasPrefix(trimmed, ".scrape ") || strings.HasPrefix(trimmed, ".prom_scrape ") || strings.HasPrefix(trimmed, ".prom_scrape_range ") {
 			after := trimmed[len(".scrape "):]
 			// Only offer suggestions if no space yet (still typing URL)
 			if !strings.Contains(after, " ") {


### PR DESCRIPTION
* add ad-hoc commands for remote prometheus v1/api endpoint scraping: `.prom_scrape` and `.prom_scrape_range`
* support for basic and mimir auth in `.prom_scrape` and `.prom_scrape_range`
* split `adhoc.go` into more functional `adhoc_<feat>.go` files
--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
