### PR TITLE
add [timestamp=<...>][regex=<...>] to .load/.save, add .stats, fix Make/Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 ROOT := $(shell pwd)
 BIN := $(ROOT)/bin
-APP := promql-cli
+APP := bin/promql-cli
 PKG := github.com/jjo/promql-cli
 
 TAG ?= latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 ROOT := $(shell pwd)
 BIN := $(ROOT)/bin
-APP := bin/promql-cli
+APP := promql-cli
 PKG := github.com/jjo/promql-cli
 
 TAG ?= latest
@@ -33,7 +33,7 @@ build: $(BIN) build-binary
 
 # Build a single binary at repo root (./promql-cli)
 build-binary:
-	GOFLAGS=$(GOFLAGS) CGO_ENABLED=0 go build -tags "$(BUILD_TAGS)" -trimpath -ldflags "$(LDFLAGS)" -o $(APP) ./cmd/cli/...
+	GOFLAGS=$(GOFLAGS) CGO_ENABLED=0 go build -tags "$(BUILD_TAGS)" -trimpath -ldflags "$(LDFLAGS)" -o bin/$(APP) ./cmd/cli/...
 	@echo "Built $(BIN)/$(APP) (version=$(GIT_VERSION), commit=$(GIT_COMMIT), tags=$(BUILD_TAGS))"
 
 # Build without prompt support (minimal binary)
@@ -70,6 +70,7 @@ docker-build:
 		--build-arg VERSION=$(GIT_VERSION) \
 		--build-arg COMMIT=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		--build-arg BUILD_TAGS=$(BUILD_TAGS) \
 		-t $(IMAGE) .
 
 # Example: make docker-run ARGS="query /data/metrics.prom"

--- a/pkg/ai/ai_test.go
+++ b/pkg/ai/ai_test.go
@@ -1,0 +1,142 @@
+package ai
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	sstorage "github.com/jjo/promql-cli/pkg/storage"
+)
+
+func TestFieldsRespectQuotes(t *testing.T) {
+	in := `provider=claude model="sonnet 3.5" base='https://api.example/v1' answers=3`
+	got := fieldsRespectQuotes(in)
+	want := []string{
+		"provider=claude",
+		"model=\"sonnet 3.5\"",
+		"base='https://api.example/v1'",
+		"answers=3",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fieldsRespectQuotes diff:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestMergeKV(t *testing.T) {
+	dst := map[string]string{}
+	mergeKV(dst, "provider=openai, model=gpt-4o-mini answers=2")
+	if dst["provider"] != "openai" || dst["model"] != "gpt-4o-mini" || dst["answers"] != "2" {
+		t.Fatalf("mergeKV failed, got=%v", dst)
+	}
+}
+
+func TestConfigureAIComposite_OpenAI(t *testing.T) {
+	backupEnv := os.Environ()
+	defer func() {
+		// restore env by clearing and resetting minimal for safety
+		for _, e := range os.Environ() {
+			k := strings.SplitN(e, "=", 2)[0]
+			_ = os.Unsetenv(k)
+		}
+		for _, e := range backupEnv {
+			kv := strings.SplitN(e, "=", 2)
+			if len(kv) == 2 {
+				_ = os.Setenv(kv[0], kv[1])
+			}
+		}
+	}()
+	// Clear globals relevant to provider
+	aiProviderFlag, aiOpenAIModelFlag, aiOpenAIBaseFlag = "", "", ""
+	os.Setenv("PROMQL_CLI_AI", "")
+
+	ConfigureAIComposite(map[string]string{
+		"provider": "openai",
+		"model":    "gpt-4o-mini",
+		"base":     "https://api.openai.com/v1",
+		"answers":  "4",
+	})
+	if aiProviderFlag != "openai" {
+		t.Fatalf("expected provider openai, got %s", aiProviderFlag)
+	}
+	if aiOpenAIModelFlag != "gpt-4o-mini" {
+		t.Fatalf("expected model gpt-4o-mini, got %s", aiOpenAIModelFlag)
+	}
+	if !strings.Contains(aiOpenAIBaseFlag, "openai.com") {
+		t.Fatalf("expected base to contain openai.com, got %s", aiOpenAIBaseFlag)
+	}
+}
+
+func TestBuildAIPromptContextAndPrompt(t *testing.T) {
+	st := sstorage.NewSimpleStorage()
+	// Create two series for metric http_requests_total with labels method/code
+	st.Metrics["http_requests_total"] = []sstorage.MetricSample{
+		{Labels: map[string]string{"__name__": "http_requests_total", "method": "GET", "code": "200"}, Value: 1},
+		{Labels: map[string]string{"__name__": "http_requests_total", "method": "POST", "code": "500"}, Value: 2},
+	}
+	st.MetricsHelp["http_requests_total"] = "HTTP requests"
+
+	ctx := buildAIPromptContext(st)
+	if len(ctx.Metrics) == 0 || ctx.Metrics[0].Name != "http_requests_total" {
+		t.Fatalf("expected metric in context, got=%v", ctx.Metrics)
+	}
+	// Labels sorted
+	if got := strings.Join(ctx.Metrics[0].Labels, ","); got != "code,method" {
+		t.Fatalf("expected labels sorted code,method; got %s", got)
+	}
+
+	p := buildAIPrompt(ctx, "errors over time")
+	if !strings.Contains(p, "Task: errors over time") {
+		t.Fatalf("prompt missing task, got: %s", p)
+	}
+	if !strings.Contains(p, "http_requests_total") || !strings.Contains(p, "labels:") {
+		t.Fatalf("prompt missing metric/labels: %s", p)
+	}
+}
+
+func TestParseAISuggestions_Variants(t *testing.T) {
+	// JSON answers
+	jsonAnswers := `{"answers":[{"query":"rate(http_requests_total[5m])","explain":"request rate"}]}`
+	s := parseAISuggestions(jsonAnswers)
+	if len(s) != 1 || !strings.Contains(s[0].Query, "http_requests_total") || s[0].Explain == "" {
+		t.Fatalf("parseAISuggestions answers failed: %v", s)
+	}
+	// JSON queries
+	jsonQueries := `{"queries":["up","sum(rate(x[5m]))"]}`
+	s = parseAISuggestions(jsonQueries)
+	if len(s) != 2 || s[0].Query != "up" {
+		t.Fatalf("parseAISuggestions queries failed: %v", s)
+	}
+	// Embedded JSON in text
+	emb := "foo bar {\"answers\":[{\"query\":\"up\",\"explain\":\"is up\"}]} baz"
+	s = parseAISuggestions(emb)
+	if len(s) != 1 || s[0].Query != "up" || s[0].Explain == "" {
+		t.Fatalf("parseAISuggestions embedded failed: %v", s)
+	}
+	// Fenced JSON
+	fenced := "```\n{\"queries\":[\"up\"]}\n```"
+	s = parseAISuggestions(fenced)
+	if len(s) != 1 || s[0].Query != "up" {
+		t.Fatalf("parseAISuggestions fenced json failed: %v", s)
+	}
+	// Plain lines
+	plain := "rate(foo_total[5m])\nnot-promql"
+	s = parseAISuggestions(plain)
+	if len(s) == 0 || !strings.Contains(s[0].Query, "rate(") {
+		t.Fatalf("parseAISuggestions plain failed: %v", s)
+	}
+}
+
+func TestCleanCandidate(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"`up`", "up"},
+		{"\"up\"", "up"},
+		{"'up'", "up"},
+		{"````code````", "code"},
+	}
+	for _, c := range cases {
+		if got := CleanCandidate(c.in); got != c.want {
+			t.Fatalf("CleanCandidate(%q)=%q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/repl/adhoc.go
+++ b/pkg/repl/adhoc.go
@@ -46,6 +46,13 @@ func handleAdHocFunction(query string, storage *sstorage.SimpleStorage) bool {
 		}
 	}
 
+	// .stats: show totals
+	if trimmed == ".stats" {
+		if handled := handleAdhocStats(trimmed, storage); handled {
+			return true
+		}
+	}
+
 	// Handle .labels <metric>
 	if strings.HasPrefix(trimmed, ".labels") {
 		if handled := handleAdhocLabels(trimmed, storage); handled {

--- a/pkg/repl/adhoc_commands.go
+++ b/pkg/repl/adhoc_commands.go
@@ -43,16 +43,32 @@ var AdHocCommands = []AdHocCommand{
 		Examples:    []string{".timestamps http_requests_total"},
 	},
 	{
+		Command:     ".stats",
+		Description: "Show current store totals (metrics and samples)",
+		Usage:       ".stats",
+	},
+{
 		Command:     ".load",
 		Description: "Load metrics from a Prometheus text-format file",
-		Usage:       ".load <file.prom>",
-		Examples:    []string{".load metrics.prom"},
+		Usage:       ".load <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']",
+		Examples: []string{
+			".load metrics.prom",
+			".load metrics.prom timestamp=now",
+			".load metrics.prom timestamp=2025-09-28T12:00:00Z",
+			".load metrics.prom timestamp=remove",
+			".load metrics.prom regex='^up\\{.*\\}$'",
+		},
 	},
-	{
+{
 		Command:     ".save",
 		Description: "Save current store to a Prometheus text-format file",
-		Usage:       ".save <file.prom>",
-		Examples:    []string{".save snapshot.prom"},
+		Usage:       ".save <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']",
+		Examples: []string{
+			".save snapshot.prom",
+			".save snapshot.prom timestamp=now",
+			".save snapshot.prom timestamp=remove",
+			".save snapshot.prom regex='http_requests_total\\{.*code=\"5..\".*\\}'",
+		},
 	},
 	{
 		Command:     ".seed",

--- a/pkg/repl/adhoc_handle_file.go
+++ b/pkg/repl/adhoc_handle_file.go
@@ -149,7 +149,7 @@ func applyTimestampOverride(storage *sstorage.SimpleStorage, beforeCounts map[st
 		}
 		for i := start; i < len(samples); i++ {
 			if mode == "remove" {
-				// simulate missing timestamps by using a single current time
+				// set a uniform timestamp (current time) for all samples when 'remove' mode is used
 				storage.Metrics[name][i].Timestamp = time.Now().UnixMilli()
 			} else if mode == "set" {
 				storage.Metrics[name][i].Timestamp = fixed

--- a/pkg/repl/adhoc_handle_file.go
+++ b/pkg/repl/adhoc_handle_file.go
@@ -3,25 +3,49 @@ package repl
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	sstorage "github.com/jjo/promql-cli/pkg/storage"
 )
 
 func handleAdhocSave(query string, storage *sstorage.SimpleStorage) bool {
-	path := strings.TrimSpace(strings.TrimPrefix(query, ".save"))
-	path = strings.Trim(path, " \"'")
-	if path == "" {
-		fmt.Println("Usage: .save <file.prom>")
+	rest := strings.TrimSpace(strings.TrimPrefix(query, ".save"))
+	if rest == "" {
+fmt.Println("Usage: .save <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']")
 		return true
 	}
+	// Parse path (quoted or unquoted) and optional key=value tokens
+	path, args := parsePathAndArgs(rest)
+	if path == "" {
+fmt.Println("Usage: .save <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']")
+		return true
+	}
+	// Parse optional timestamp and regex
+	tsMode, tsFixed, ok := parseTimestampArg(args)
+	if !ok {
+		fmt.Println("Invalid timestamp specification. Use: timestamp={now|remove|<timespec>}")
+		return true
+	}
+	re, ok := parseRegexArg(args)
+	if !ok {
+		fmt.Println("Invalid regex specification. Use: regex='timeseries regex' (quote if it contains spaces)")
+		return true
+	}
+
 	f, err := os.Create(path)
 	if err != nil {
 		fmt.Printf("Failed to open %s for writing: %v\n", path, err)
 		return true
 	}
 	defer f.Close()
-	if err := storage.SaveToWriter(f); err != nil {
+	opts := sstorage.SaveOptions{TimestampMode: tsMode, FixedTimestamp: tsFixed}
+	if re != nil {
+		opts.SeriesRegex = re
+	}
+	if err := storage.SaveToWriterWithOptions(f, opts); err != nil {
 		fmt.Printf("Failed to save metrics to %s: %v\n", path, err)
 		return true
 	}
@@ -29,13 +53,154 @@ func handleAdhocSave(query string, storage *sstorage.SimpleStorage) bool {
 	return true
 }
 
+// parsePathAndArgs splits first path token (quoted or unquoted) and returns the rest tokens for key=value options.
+func parsePathAndArgs(rest string) (string, []string) {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "", nil
+	}
+	if rest[0] == '\'' || rest[0] == '"' {
+		quote := rest[0]
+		i := 1
+		for i < len(rest) && rest[i] != quote {
+			i++
+		}
+		if i >= len(rest) {
+			// unterminated
+			return strings.Trim(rest[1:], " \t\n\r"), nil
+		}
+		path := rest[1:i]
+		remainder := strings.TrimSpace(rest[i+1:])
+		var args []string
+		if remainder != "" {
+			args = strings.Fields(remainder)
+		}
+		return path, args
+	}
+	// unquoted
+	i := 0
+	for i < len(rest) && rest[i] != ' ' && rest[i] != '\t' {
+		i++
+	}
+	path := rest[:i]
+	remainder := strings.TrimSpace(rest[i:])
+	var args []string
+	if remainder != "" {
+		args = strings.Fields(remainder)
+	}
+	return path, args
+}
+
+// parseTimestampArg scans args for timestamp=... and returns (mode, fixedMs, ok)
+// mode is one of: keep (default), remove, set
+func parseTimestampArg(args []string) (string, int64, bool) {
+	mode := "keep"
+	if len(args) == 0 {
+		return mode, 0, true
+	}
+	for _, a := range args {
+		if !strings.HasPrefix(strings.ToLower(a), "timestamp=") {
+			continue
+		}
+		val := strings.TrimSpace(a[len("timestamp="):])
+		val = strings.Trim(val, " \"'")
+		if strings.EqualFold(val, "remove") {
+			return "remove", 0, true
+		}
+		if strings.EqualFold(val, "now") {
+			return "set", time.Now().UnixMilli(), true
+		}
+		// timespec parsed via parseEvalTime (supports now+/-dur, rfc3339, unix)
+		t, err := parseEvalTime(val)
+		if err != nil {
+			return "keep", 0, false
+		}
+		return "set", t.UnixMilli(), true
+	}
+	return mode, 0, true
+}
+
+// parseRegexArg finds regex=... and returns a compiled regexp (or nil if absent).
+func parseRegexArg(args []string) (*regexp.Regexp, bool) {
+	for _, a := range args {
+		if !strings.HasPrefix(strings.ToLower(a), "regex=") {
+			continue
+		}
+		val := strings.TrimSpace(a[len("regex="):])
+		val = strings.Trim(val, " \"'")
+		if val == "" {
+			return nil, false
+		}
+		re, err := regexp.Compile(val)
+		if err != nil {
+			return nil, false
+		}
+		return re, true
+	}
+	return nil, true
+}
+
+// applyTimestampOverride updates only newly loaded samples to the given mode
+func applyTimestampOverride(storage *sstorage.SimpleStorage, beforeCounts map[string]int, mode string, fixed int64) {
+	for name, samples := range storage.Metrics {
+		start := beforeCounts[name]
+		if start < 0 || start > len(samples) {
+			start = 0
+		}
+		for i := start; i < len(samples); i++ {
+			if mode == "remove" {
+				// simulate missing timestamps by using a single current time
+				storage.Metrics[name][i].Timestamp = time.Now().UnixMilli()
+			} else if mode == "set" {
+				storage.Metrics[name][i].Timestamp = fixed
+			}
+		}
+	}
+}
+
+// seriesSignature builds name{labels} (labels sorted, quoted) signature for regex matching.
+func seriesSignature(name string, lbls map[string]string) string {
+	// Exclude __name__
+	keys := make([]string, 0, len(lbls))
+	for k := range lbls {
+		if k == "__name__" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := lbls[k]
+		v = strings.ReplaceAll(v, "\\", "\\\\")
+		v = strings.ReplaceAll(v, "\n", "\\n")
+		v = strings.ReplaceAll(v, "\t", "\\t")
+		v = strings.ReplaceAll(v, "\"", "\\\"")
+		parts = append(parts, fmt.Sprintf("%s=\"%s\"", k, v))
+	}
+	if len(parts) == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s{%s}", name, strings.Join(parts, ","))
+}
+
 func handleAdhocLoad(query string, storage *sstorage.SimpleStorage) bool {
-	path := strings.TrimSpace(strings.TrimPrefix(query, ".load"))
-	path = strings.Trim(path, " \"'")
-	if path == "" {
-		fmt.Println("Usage: .load <file.prom>")
+	rest := strings.TrimSpace(strings.TrimPrefix(query, ".load"))
+	if rest == "" {
+fmt.Println("Usage: .load <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']")
 		return true
 	}
+	path, args := parsePathAndArgs(rest)
+	if path == "" {
+fmt.Println("Usage: .load <file.prom> [timestamp={now|remove|<timespec>}] [regex='<series regex>']")
+		return true
+	}
+	// capture per-metric counts to adjust only newly loaded samples when overriding timestamps
+	beforeCounts := make(map[string]int)
+	for name, ss := range storage.Metrics {
+		beforeCounts[name] = len(ss)
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		fmt.Printf("Failed to open %s: %v\n", path, err)
@@ -47,15 +212,49 @@ func handleAdhocLoad(query string, storage *sstorage.SimpleStorage) bool {
 	for _, ss := range storage.Metrics {
 		beforeSamples += len(ss)
 	}
-	if err := storage.LoadFromReader(f); err != nil {
-		fmt.Printf("Failed to load metrics from %s: %v\n", path, err)
+	// Parse optional timestamp and regex
+	tsMode, tsFixed, ok := parseTimestampArg(args)
+	if !ok {
+		fmt.Println("Invalid timestamp specification. Use: timestamp={now|remove|<timespec>}")
 		return true
 	}
-	afterMetrics := len(storage.Metrics)
-	afterSamples := 0
-	for _, ss := range storage.Metrics {
-		afterSamples += len(ss)
+	re, ok := parseRegexArg(args)
+	if !ok {
+		fmt.Println("Invalid regex specification. Use: regex='timeseries regex' (quote if it contains spaces)")
+		return true
 	}
+	if re == nil {
+		if err := storage.LoadFromReader(f); err != nil {
+			fmt.Printf("Failed to load metrics from %s: %v\n", path, err)
+			return true
+		}
+		if tsMode != "keep" {
+			applyTimestampOverride(storage, beforeCounts, tsMode, tsFixed)
+		}
+	} else {
+		// Load into temp storage and merge matching series only
+		tmp := sstorage.NewSimpleStorage()
+		if err := tmp.LoadFromReader(f); err != nil {
+			fmt.Printf("Failed to load metrics from %s: %v\n", path, err)
+			return true
+		}
+		for name, samples := range tmp.Metrics {
+			for _, s := range samples {
+				seriesSig := seriesSignature(name, s.Labels)
+				if re.MatchString(seriesSig) {
+					ts := s.Timestamp
+					if tsMode == "remove" {
+						ts = time.Now().UnixMilli()
+					} else if tsMode == "set" {
+						ts = tsFixed
+					}
+					storage.AddSample(s.Labels, s.Value, ts)
+				}
+			}
+		}
+	}
+
+	afterMetrics, afterSamples := storeTotals(storage)
 	fmt.Printf("Loaded %s: +%d metrics, +%d samples (total: %d metrics, %d samples)\n", path, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
 
 	// Refresh metrics cache for autocompletion if using prompt backend

--- a/pkg/repl/adhoc_handle_http.go
+++ b/pkg/repl/adhoc_handle_http.go
@@ -112,13 +112,9 @@ func handleAdhocScrape(query string, storage *sstorage.SimpleStorage) bool {
 			}
 		}()
 
-		afterMetrics := len(storage.Metrics)
-		afterSamples := 0
-		for _, ss := range storage.Metrics {
-			afterSamples += len(ss)
-		}
-		fmt.Printf("Scraped %s (%d/%d): +%d metrics, +%d samples (total: %d metrics, %d samples)\n",
-			uri, i+1, count, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
+	afterMetrics, afterSamples := storeTotals(storage)
+	fmt.Printf("Scraped %s (%d/%d): +%d metrics, +%d samples (total: %d metrics, %d samples)\n",
+		uri, i+1, count, afterMetrics-beforeMetrics, afterSamples-beforeSamples, afterMetrics, afterSamples)
 
 		if i < count-1 && delay > 0 {
 			time.Sleep(delay)
@@ -201,11 +197,7 @@ func handleAdhocPromScrapeCommand(input string, storage *sstorage.SimpleStorage)
 			}
 			// Import results
 			added := importPromResultIntoStorage(storage, &pr)
-			afterMetrics := len(storage.Metrics)
-			afterSamples := 0
-			for _, ss := range storage.Metrics {
-				afterSamples += len(ss)
-			}
+			afterMetrics, afterSamples := storeTotals(storage)
 			fmt.Printf("Imported from %s (%d/%d): +%d samples (total: %d metrics, %d samples)\n",
 				u.Scheme+"://"+u.Host, i+1, count, added, afterMetrics, afterSamples)
 		}()
@@ -563,11 +555,7 @@ func handleAdhocPromScrapeRangeCommand(input string, storage *sstorage.SimpleSto
 				return
 			}
 			added := importPromResultIntoStorage(storage, &pr)
-			afterMetrics := len(storage.Metrics)
-			afterSamples := 0
-			for _, ss := range storage.Metrics {
-				afterSamples += len(ss)
-			}
+			afterMetrics, afterSamples := storeTotals(storage)
 			fmt.Printf("Imported range from %s (%d/%d): +%d samples (total: %d metrics, %d samples)\n",
 				u.Scheme+"://"+u.Host, i+1, count, added, afterMetrics, afterSamples)
 		}()

--- a/pkg/repl/adhoc_handle_metrics.go
+++ b/pkg/repl/adhoc_handle_metrics.go
@@ -10,6 +10,22 @@ import (
 	sstorage "github.com/jjo/promql-cli/pkg/storage"
 )
 
+// storeTotals returns (#metrics, #samples) for the current store
+func storeTotals(storage *sstorage.SimpleStorage) (int, int) {
+	totalMetrics := len(storage.Metrics)
+	totalSamples := 0
+	for _, ss := range storage.Metrics {
+		totalSamples += len(ss)
+	}
+	return totalMetrics, totalSamples
+}
+
+func handleAdhocStats(_ string, storage *sstorage.SimpleStorage) bool {
+	tm, ts := storeTotals(storage)
+	fmt.Printf("Total: %d metrics, %d samples\n", tm, ts)
+	return true
+}
+
 func handleAdhocMetrics(query string, storage *sstorage.SimpleStorage) bool {
 	if len(storage.Metrics) == 0 {
 		fmt.Println("No metrics loaded")
@@ -233,11 +249,7 @@ func handleAdhocDrop(query string, storage *sstorage.SimpleStorage) bool {
 	removed := len(samples)
 	delete(storage.Metrics, metric)
 	// Report new totals
-	totalMetrics := len(storage.Metrics)
-	totalSamples := 0
-	for _, ss := range storage.Metrics {
-		totalSamples += len(ss)
-	}
+	totalMetrics, totalSamples := storeTotals(storage)
 	fmt.Printf("Dropped '%s': -%d samples (now: %d metrics, %d samples)\n", metric, removed, totalMetrics, totalSamples)
 
 	// Refresh metrics cache for autocompletion if using prompt backend

--- a/pkg/repl/adhoc_test.go
+++ b/pkg/repl/adhoc_test.go
@@ -361,6 +361,22 @@ func TestAdhoc_Labels_ExistingMissingAndUsage(t *testing.T) {
 	}
 }
 
+func TestAdhoc_Save_WithTimestamp_ParsesPathAndArgs(t *testing.T) {
+	dir := t.TempDir()
+	store := sstorage.NewSimpleStorage()
+	path := filepath.Join(dir, "foo.prom")
+	out := captureStdout(t, func() { _ = handleAdhocSave(".save "+path+" timestamp=remove", store) })
+	if !strings.Contains(out, "Saved store to "+path) {
+		t.Fatalf("expected saved message with path only, got: %s", out)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file %s to be created: %v", path, err)
+	}
+	if _, err := os.Stat(path+" timestamp=remove"); err == nil {
+		t.Fatalf("unexpected file created with args in name: %s", path+" timestamp=remove")
+	}
+}
+
 func TestAdhoc_Seed_KVAndPositional(t *testing.T) {
 	store := sstorage.NewSimpleStorage()
 	if err := store.LoadFromReader(strings.NewReader(sstorage.SampleMetrics)); err != nil {


### PR DESCRIPTION
- adhoc: add `[timestamp={remove|now|<spec>] [regex=<series regex>]` to `.load` and `.save`, add `.stats` adhoc cmd
- consolidate `Dockerfile` to use `make`, fix `Makefile` for `APP=promql-cli`
- when pasting from `.ai` suggestions, add `# <help text>` to the query line
- add super-basic `pkg/ai/ai_test.go`

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
