### PR TITLE
fix(readline): removing last leftword deletes the wholeline issue

### DIFF
--- a/pkg/repl/prompt_repl.go
+++ b/pkg/repl/prompt_repl.go
@@ -1283,6 +1283,11 @@ func (r *promptREPL) Run() error {
 				for start >= 0 && strings.ContainsRune(separators, rune(text[start])) {
 					start--
 				}
+				// If we only found separators and reached start, delete just the separators
+				if start < 0 {
+					buf.DeleteBeforeCursor(pos)
+					return
+				}
 				// Find beginning of word
 				for start >= 0 && !strings.ContainsRune(separators, rune(text[start])) {
 					start--
@@ -1363,6 +1368,11 @@ func (r *promptREPL) Run() error {
 					// Skip trailing separators
 					for start >= 0 && strings.ContainsRune(separators, rune(text[start])) {
 						start--
+					}
+					// If we only found separators and reached start, delete just the separators
+					if start < 0 {
+						buf.DeleteBeforeCursor(pos)
+						return
 					}
 					// Find beginning of word
 					for start >= 0 && !strings.ContainsRune(separators, rune(text[start])) {

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -189,7 +189,7 @@ func runInteractiveQueries(engine *promql.Engine, storage *sstorage.SimpleStorag
 		}
 		// If we only found separators and reached start, delete just the separators
 		if i == 0 {
-			newLine := append([]rune(nil), line[pos:]...)
+			newLine := append([]rune(nil), line[i:]...)
 			return newLine, 0
 		}
 		// Then delete the previous word

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -218,9 +218,7 @@ func runInteractiveQueries(engine *promql.Engine, storage *sstorage.SimpleStorag
 			// Apply our correct deletion logic using the previous state
 			// This handles Ctrl-W (23) and potentially Ctrl-Backspace which might not even reach us as a distinct key
 			nl, np := deletePrevWord(prevLine, prevPos)
-			// Save state for next iteration
-			prevLine = append(prevLine[:0], nl...)
-			prevPos = np
+			// Do not update prevLine/prevPos here; let the REPL main loop handle state updates
 			return nl, np, true
 		}
 

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -472,11 +472,8 @@ func runInteractiveQueries(engine *promql.Engine, storage *sstorage.SimpleStorag
 
 		// Save current state for next keystroke (for Ctrl-W fix)
 		// Make a copy to avoid shared slice issues
-		if len(line) > 0 {
-			prevLine = append(prevLine[:0], line...)
-			prevPos = pos
-		}
-
+		prevLine = append(prevLine[:0], line...)
+		prevPos = pos
 		return nil, 0, false
 	}
 


### PR DESCRIPTION
Fixes a bug in the readline library where pressing Ctrl-W or Ctrl-Backspace on the last word of a line incorrectly deletes the entire line instead of just the word. The fix tracks previous line state and restores the correct behavior when this bug is detected.

* Adds detection for when readline incorrectly clears the entire line during word deletion
* Implements proper PromQL-aware word deletion logic with edge case handling
* Adds support for ESC+Backspace/DEL word deletion shortcuts

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
